### PR TITLE
New path for Command-line tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,21 @@ $ rm -r Scout
 
 ##### Download
 
-If you cannot use those methods, you can rather download the latest version of the executable [here](https://alexis-bridoux-perso.s3.us-east-2.amazonaws.com/scout-0-1-4.zip).
+If you cannot use those methods, you can rather download the latest version of the executable [here](https://abridoux-public.s3.us-east-2.amazonaws.com/scout/scout-latest.zip).
 After having unzipped the file, you can install it if you want to:
 
 ```bash
 install scout /usr/local/bin/ 
+```
+
+Here is a command which downloads the latest version of the programm and install it in */usr/local/bin*. 
+Run it to download and install the latest version of the program. It erases the current version you may have.
+
+```bash
+curl -o scout.zip https://abridoux-public.s3.us-east-2.amazonaws.com/scout/scout-latest.zip \
+unzip scout.zip && \
+rm scout.zip && \
+install scout /usr/local/bin
 ```
 
 #### Usage examples
@@ -85,44 +95,45 @@ Given the following Json (as input stream or file with the `input` option)
 ```
 
 ##### Reading
-`scout "people->Tom->hobbies->[0]"` will output "cooking"
+`scout "people.Tom.hobbies[0]"` will output "cooking"
 
-`scout "people->Arnaud->height"` will output "180"
+`scout "people.Arnaud.height"` will output "180"
 
 ##### Setting
-`scout set "people->Tom->hobbies->[0]":basket` will change Tom first hobby from "cooking" to "basket"
+`scout set "people.Tom.hobbies[0]"=basket` will change Tom first hobby from "cooking" to "basket"
 
-`scout set "people->Arnaud->height":160` will change Arnaud's height from 180 to 160
+`scout set "people.Arnaud.height"=160` will change Arnaud's height from 180 to 160
 
-`scout set "people->Tom->hobbies->[0]":basket "people->Arnaud->height":160` will change Tom first hobby from "cooking" to "basket" **and** change Arnaud's height from 180 to 160
+`scout set "people.Tom.hobbies[0]"=basket "people.Arnaud.height"=160` will change Tom first hobby from "cooking" to "basket" **and** change Arnaud's height from 180 to 160
 
-`scout set "people->Tom->age":#years#` will change Tom age key name from #age# to #years#
+`scout set "people.Tom.age"=#years#` will change Tom age key name from #age# to #years#
 
-`scout set "people->Tom->height":/175/` will change Tom height from 180 to a **String value** "175"
+`scout set "people.Tom.height"=/175/` will change Tom height from 180 to a **String value** "175"
 
 ##### Deleting
-`scout delete "people->Tom>height"` will delete Tom height
-`scout delete "people->Tom>hobbies->[0]"` will delete Tom first hobby
+`scout delete "people.Tom.height"` will delete Tom height
+`scout delete "people.Tom.hobbies[0]"` will delete Tom first hobby
 
 ##### Adding
-`scout add "people->Franklin->height":165` will create a new dictionary Franklin and add a height key into it with the value 165
+`scout add "people.Franklin.height"=165` will create a new dictionary Franklin and add a height key into it with the value 165
 
-`scout add "people->Tom->hobbies->[-1]:"Playing music"` will add the hobby "Playing music" to Tom hobbies at the end of the array
+`scout add "people.Tom.hobbies[-1]="Playing music"` will add the hobby "Playing music" to Tom hobbies at the end of the array
 
-`scout add "people->Arnaud->hobbies->[1]:reading` will insert the hobby "reading" to Arnaud hobbies between the hobby "video games" and "party"
+`scout add "people.Arnaud.hobbies[1]"=reading` will insert the hobby "reading" to Arnaud hobbies between the hobby "video games" and "party"
 
-`scout add "people->Franklin->hobbies->[0]":"football"` will create a new dictionary Franklin, add a hobbies array into it, and insert the value "football" in the array
+`scout add "people.Franklin.hobbies[0]"=football` will create a new dictionary Franklin, add a hobbies array into it, and insert the value "football" in the array
 
-`scout add "people->Franklin->height":/165/` will create a new dictionary Franklin and add a height key into it with the **String value** "165"
+`scout add "people.Franklin.height"=/165/` will create a new dictionary Franklin and add a height key into it with the **String value** "165"
 
 #### Options
 Each command will have several options, like the possibility to output the modified data to string or into a file.
 
-`cat People.json | scout "people->Tom->height" ` is the same as `scout "people->Tom->height -i People.json `
+`cat People.json | scout "people.Tom.height" ` is the same as 
+`scout "people.Tom.height -i People.json `
 
-`scout set "people->Tom height":190 "people->Arnaud->hobbies->[1]":"football" -o People.json` will copy the content in the file *People.json*, modify it and write it back to *People.json*
+`scout set "people.Tom.height"=190 "people.Arnaud.hobbies[1]"=football -o People.json` will copy the content in the file *People.json*, modify it and write it back to *People.json*
 
-`scout set "people->Tom height":190 "people->Arnaud->hobbies->[1]":"football" -v` will output the modified data.
+`scout set "people.Tom.height"=190 "people.Arnaud.hobbies[1]"=football -v` will output the modified data.
 
 ### Swift
 

--- a/Sources/Scout/Definitions/Path.swift
+++ b/Sources/Scout/Definitions/Path.swift
@@ -19,33 +19,77 @@ public extension Path {
         description.removeLast(2)
         return description
     }
-    /**
-    Instantiate a `Path` for a string representing path components separated with arrows
 
-     ### Example with default separator "->"
-     - ```computers->[2]->name``` will make the path ["computers", 2, "name"]
-     - ```computer->general->serial_number``` will make the path ["computer", "general", "serial_number"]
+    /**
+     Instantiate a `Path` for a string representing path components separated with the separator.
+
+     ### Example with default separator "."
+
+     ```computers[2].name``` will make the path ["computers", 2, "name"]
+     ```computer.general.serial_number``` will make the path ["computer", "general", "serial_number"]
 
      - parameter string: The string representing the path
-     - parameter separator: The separator used to split the string. Default is "->"
+     - parameter separator: The separator used to split the string. Default is "."
+
+     - note: When enclosed with brackets, a path element will not be parsed. For example ```computer.(general.information).serial_number```
+     will make the path ["computer", "general.information", "serial_number"]
+
     */
-    init(string: String, separator: String = "->") throws {
+    init(string: String, separator: String = ".") throws {
         var elements = [PathElement]()
 
-        try string.components(separatedBy: separator).map { $0.trimmingCharacters(in: .whitespaces) }.forEach { element in
+        let pattern = #"(?<=(^|\.))(\(.+\)|[^\.]+)(?=(\.|$))"#
+        let regex = try NSRegularExpression(pattern: pattern, options: [.anchorsMatchLines])
+        let indexPattern = #"(?<=\[)[0-9]+(?=\])"#
+        let indexRegex = try NSRegularExpression(pattern: indexPattern, options: [])
 
-            if element.hasPrefix("["), element.hasSuffix("]") {
-                // array index so remove the square brackets and try to convert to int
-                let indexComponentString = element[1..<element.count - 1]
-                guard let indexComponent = Int(indexComponentString) else {
-                    throw PathExplorerError.stringToIntConversionError(string)
-                }
+        let matches = regex.matches(in: string)
+        for match in matches {
 
-                elements.append(indexComponent)
+            // remove the brackets if any
+            var match = match
+            if match.hasPrefix("("), match.hasSuffix(")") {
+                match.removeFirst()
+                match.removeLast()
+            }
+
+            // try to get the index if any
+            if let indexMatch = indexRegex.firstMatch(in: match, options: [], range: match.nsRange) {
+                guard indexMatch.range.lowerBound > 1 else { throw PathExplorerError.invalidPathElement(match) }
+                // get the array name
+                let newMatch = String(match[0..<indexMatch.range.lowerBound - 1])
+                // get the array index
+                guard let index = Int(match[indexMatch.range]) else { throw PathExplorerError.invalidPathElement(match) }
+
+                elements.append(newMatch)
+                elements.append(index)
+
             } else {
-                elements.append(String(element))
+                elements.append(match)
             }
         }
+
         self = elements
+    }
+}
+
+extension Path {
+    static func ==(lhs: Path, rhs: Path) -> Bool {
+        guard lhs.count == rhs.count else { return false }
+
+        var isEqual = true
+        for (leftElement, rightElement) in zip(lhs, rhs) {
+            if let leftString = leftElement as? String {
+                guard let rightString = rightElement as? String else { return false }
+                isEqual = isEqual && leftString == rightString
+            } else if let leftInt = leftElement as? Int {
+                guard let rightInt = rightElement as? Int else { return false }
+                isEqual = isEqual && rightInt == leftInt
+            } else {
+                assertionFailure("Only String and Int can be PathElement")
+                return false
+            }
+        }
+        return isEqual
     }
 }

--- a/Sources/Scout/Definitions/PathElement.swift
+++ b/Sources/Scout/Definitions/PathElement.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Components to subscript a `PathExplorer`
-public protocol PathElement {}
+public protocol PathElement: Codable {}
 
 extension String: PathElement {}
 extension Int: PathElement {}

--- a/Sources/Scout/Definitions/PathExplorerError.swift
+++ b/Sources/Scout/Definitions/PathExplorerError.swift
@@ -14,7 +14,6 @@ enum PathExplorerError: LocalizedError {
     case stringToDataConversionError
     case dataToStringConversionError
     case invalidPathElement(PathElement)
-    case unmatchingBracket(PathElement)
 
     case underlyingError(String)
 
@@ -33,7 +32,6 @@ enum PathExplorerError: LocalizedError {
         case .stringToDataConversionError: return "Unable to convert the input string into data"
         case .dataToStringConversionError: return "Unable to convert the data to a string"
         case .invalidPathElement(let element): return "Invalid path element: \(element)"
-        case .unmatchingBracket(let element): return "Unmatching bracket in path element \(element)"
 
         case .underlyingError(let description): return description
         }

--- a/Sources/Scout/Definitions/PathExplorerError.swift
+++ b/Sources/Scout/Definitions/PathExplorerError.swift
@@ -13,7 +13,8 @@ enum PathExplorerError: LocalizedError {
 
     case stringToDataConversionError
     case dataToStringConversionError
-    case stringToIntConversionError(String)
+    case invalidPathElement(PathElement)
+    case unmatchingBracket(PathElement)
 
     case underlyingError(String)
 
@@ -31,7 +32,9 @@ enum PathExplorerError: LocalizedError {
 
         case .stringToDataConversionError: return "Unable to convert the input string into data"
         case .dataToStringConversionError: return "Unable to convert the data to a string"
-        case .stringToIntConversionError(let string): return "Unable to convert \(string) to int"
+        case .invalidPathElement(let element): return "Invalid path element: \(element)"
+        case .unmatchingBracket(let element): return "Unmatching bracket in path element \(element)"
+
         case .underlyingError(let description): return description
         }
     }

--- a/Sources/Scout/Extensions/NSRegularExpression+Extensions.swift
+++ b/Sources/Scout/Extensions/NSRegularExpression+Extensions.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+extension NSRegularExpression {
+
+    func matches(in string: String) -> [String] {
+        let matches = self.matches(in: string, options: [], range: NSRange(location: 0, length: string.count))
+        return matches.map { String(string[$0.range]) }
+    }
+}

--- a/Sources/Scout/Extensions/String+Extension.swift
+++ b/Sources/Scout/Extensions/String+Extension.swift
@@ -15,7 +15,7 @@ extension String {
     subscript(_ range: NSRange) -> Substring {
         let sliceStartIndex = index(startIndex, offsetBy: range.location)
         let sliceEndIndex = index(startIndex, offsetBy: range.upperBound - 1)
-        
+
         return self[sliceStartIndex...sliceEndIndex]
     }
 }

--- a/Sources/Scout/Extensions/String+Extension.swift
+++ b/Sources/Scout/Extensions/String+Extension.swift
@@ -2,9 +2,20 @@ import Foundation
 
 extension String {
 
+    /// The NSRange of the full string
+    var nsRange: NSRange { NSRange(location: 0, length: count) }
+
     subscript(_ range: Range<Int>) -> Substring {
         let sliceStartIndex = index(startIndex, offsetBy: range.lowerBound)
         let sliceEndIndex = index(startIndex, offsetBy: range.upperBound - 1)
+
+        return self[sliceStartIndex...sliceEndIndex]
+    }
+
+    subscript(_ range: NSRange) -> Substring {
+        let sliceStartIndex = index(startIndex, offsetBy: range.location)
+        let sliceEndIndex = index(startIndex, offsetBy: range.upperBound - 1)
+        
         return self[sliceStartIndex...sliceEndIndex]
     }
 }

--- a/Sources/Scout/Implementations/PathExplorerSerialization.swift
+++ b/Sources/Scout/Implementations/PathExplorerSerialization.swift
@@ -201,12 +201,21 @@ public struct PathExplorerSerialization<F: SerializationFormat> {
             guard var dict = value as? [String: Any] else {
                 throw PathExplorerError.dictionarySubscript(value)
             }
+
+            guard dict[key] != nil else {
+                throw PathExplorerError.subscriptMissingKey(key)
+            }
+
             dict.removeValue(forKey: key)
             value = dict
 
         } else if let index = element as? Int {
             guard var array = value as? [Any] else {
                 throw PathExplorerError.arraySubscript(value)
+            }
+
+            guard 0 <= index, index < array.count else {
+                throw PathExplorerError.subscriptWrongIndex(index: index, arrayCount: array.count)
             }
 
             array.remove(at: index)

--- a/Sources/ScoutCLT/AddCommand.swift
+++ b/Sources/ScoutCLT/AddCommand.swift
@@ -35,15 +35,15 @@ Given the following Json (as input stream or file)
   }
 }
 
-`scout add "people->Franklin->height":165` will create a new dictionary Franklin and add a height key into it with the value 165
+`scout add "people.Franklin.height"=165` will create a new dictionary Franklin and add a height key into it with the value 165
 
-`scout add "people->Tom->hobbies->[-1]:"Playing music"` will add the hobby "Playing music" to Tom hobbies at the end of the array
+`scout add "people.Tom.hobbies[-1]"="Playing music"` will add the hobby "Playing music" to Tom hobbies at the end of the array
 
-`scout add "people->Arnaud->hobbies->[1]:reading` will insert the hobby "reading" to Arnaud hobbies between the hobby "video games" and "party"
+`scout add "people.Arnaud.hobbies[1]"=reading` will insert the hobby "reading" to Arnaud hobbies between the hobby "video games" and "party"
 
-`scout add "people->Franklin->hobbies->[0]":"football"` will create a new dictionary Franklin, add a hobbies array into it, and insert the value "football" in the array
+`scout add "people.Franklin.hobbies[0]"=football` will create a new dictionary Franklin, add a hobbies array into it, and insert the value "football" in the array
 
-`scout add "people->Franklin->height":/165/` will create a new dictionary Franklin and add a height key into it with the String value "165"
+`scout add "people.Franklin.height"=/165/` will create a new dictionary Franklin and add a height key into it with the String value "165"
 """
 
 struct AddCommand: ParsableCommand {

--- a/Sources/ScoutCLT/PathAndValue.swift
+++ b/Sources/ScoutCLT/PathAndValue.swift
@@ -14,7 +14,7 @@ struct PathAndValue: ExpressibleByArgument {
 
     // MARK: - Constants
 
-    static let help = ArgumentHelp(abstract, valueName: "path:value", shouldDisplay: true)
+    static let help = ArgumentHelp(abstract, valueName: "path=value", shouldDisplay: true)
 
     // MARK: - Properties
 
@@ -28,7 +28,7 @@ struct PathAndValue: ExpressibleByArgument {
     var forceString = false
 
     init?(argument: String) {
-        let splitted = argument.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: true)
+        let splitted = argument.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: true)
         guard
             splitted.count == 2,
             let readingPath = Path(argument: String(splitted[0]))

--- a/Sources/ScoutCLT/PathAndValue.swift
+++ b/Sources/ScoutCLT/PathAndValue.swift
@@ -4,8 +4,8 @@ import Scout
 private let abstract =
 """
 Let you specify a reading path with an associated value.
-Like this: `FirstKey->SecondKey->[FirstIndex]->ThirdKey":value`
-or `"FirstKey->[FirstIndex]":"Text value with spaces"`
+Like this: `FirstKey.SecondKey[Index].ThirdKey"=value`
+or `"FirstKey[Index]"="Text value with spaces"`
 """
 
 /// Represent a reading path and an associated value, like `path->components->[0]:value`.

--- a/Sources/ScoutCLT/ReadCommand.swift
+++ b/Sources/ScoutCLT/ReadCommand.swift
@@ -31,8 +31,8 @@ Given the following Json (as input stream or file)
 Examples
 ========
 
-- Tom first hobby: "people->Tom->hobbies->[0]" will output "cooking"
-- Arnaud height: "people->Arnaud->height" will output "180"
+- Tom first hobby: "people.Tom.hobbies[0]" will output "cooking"
+- Arnaud height: "people.Arnaud.height" will output "180"
 """
 
 struct ReadCommand: ParsableCommand {

--- a/Sources/ScoutCLT/ScoutCommand.swift
+++ b/Sources/ScoutCLT/ScoutCommand.swift
@@ -12,8 +12,8 @@ https://github.com/ABridoux/scout
 
 private let discussion =
 """
-To indicate what value to target, a path should be indicated. A path is a serie of key names or indexes separated by '->' to target one value.
-It looks like this "firt_key->second_key->[second_index]->third_key".
+To indicate what value to target, a path should be indicated. A path is a serie of key names or indexes separated by '.' to target one value.
+It looks like this "firt_key.second_key[second_index].third_key".
 
 Notes
 =====
@@ -49,26 +49,26 @@ Examples
 
 Reading
 -------
-`scout "people->Tom->hobbies->[0]"` will output "cooking"
-`scout "people->Arnaud->height"` will output "180"
+`scout "people.Tom.hobbies[0]"` will output "cooking"
+`scout "people.Arnaud.height"` will output "180"
 
 Setting
 -------
-`scout set "people->Tom->hobbies->[0]":basket` will change Tom first hobby from "cooking" to "basket"
-`scout set "people->Arnaud->height":160` will change Arnaud's height from 180 to 160
-`scout set "people->Tom->age":#years#` will change Tom age key name from #age# to #years#
+`scout set "people.Tom.hobbies[0]"=basket` will change Tom first hobby from "cooking" to "basket"
+`scout set "people.Arnaud.height"=160` will change Arnaud's height from 180 to 160
+`scout set "people.Tom.age"=#years#` will change Tom age key name from #age# to #years#
 
 Deleting
 ---------
-`scout delete "people->Tom>height"` will delete Tom height
-`scout delete "people->Tom>hobbies->[0]"` will delete Tom first hobby
+`scout delete "people.Tom.height"` will delete Tom height
+`scout delete "people.Tom.hobbies[0]"` will delete Tom first hobby
 
 Adding
 ------
-`scout add "people->Franklin->height":165` will create a new dictionary Franklin and add a height key into it with the value 165
-`scout add "people->Tom->hobbies->[-1]:"Playing music"` will add the hobby "Playing music" to Tom hobbies at the end of the array
-`scout add "people->Arnaud->hobbies->[1]:reading` will insert the hobby "reading" to Arnaud hobbies between the hobby "video games" and "party"
-`scout add "people->Franklin->hobbies->[0]":"football"` will create a new dictionary Franklin, add a hobbies array into it, and insert the value "football" in the array
+`scout add "people.Franklin.height"=165` will create a new dictionary Franklin and add a height key into it with the value 165
+`scout add "people.Tom.hobbies[-1]"=Playing music"` will add the hobby "Playing music" to Tom hobbies at the end of the array
+`scout add "people.Arnaud.hobbies[1]"=reading` will insert the hobby "reading" to Arnaud hobbies between the hobby "video games" and "party"
+`scout add "people.Franklin.hobbies[0]"="football"` will create a new dictionary Franklin, add a hobbies array into it, and insert the value "football" in the array
 """
 
 struct ScoutCommand: ParsableCommand {

--- a/Sources/ScoutCLT/SetCommand.swift
+++ b/Sources/ScoutCLT/SetCommand.swift
@@ -32,13 +32,13 @@ Given the following XML (as input stream or file)
     </url>
 </urlset>
 
-`scout set "urlset->[1]->changefreq":yearly` will change the second url #changefreq# key value to "yearly"
+`scout set "urlset[1].changefreq"=yearly` will change the second url #changefreq# key value to "yearly"
 
-`scout set "urlset->[0]->priority":2.0` will change the first url #priority# key value to 2.0.0
+`scout set "urlset[0].priority"=2.0` will change the first url #priority# key value to 2.0.0
 
-`scout set "urlset->[1]->changefreq":yearly` "urlset->[0]->priority":2.0` will change both he second url #changefreq# key value to "yearly" and the first url #priority# key value to 2.0.0
+`scout set "urlset[1].changefreq"=yearly` "urlset[0].priority"=2.0` will change both he second url #changefreq# key value to "yearly" and the first url #priority# key value to 2.0.0
 
-`scout set "urlset->[0]->changefreq":#frequence#` will change the first url #changefreq# key name to #frequence#
+`scout set "urlset[0].changefreq"=#frequence#` will change the first url #changefreq# key name to #frequence#
 """
 
 struct SetCommand: ParsableCommand {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,7 +1,0 @@
-import XCTest
-
-import SwiftyPlistTests
-
-var tests = [XCTestCaseEntry]()
-tests += SwiftyPlistTests.allTests()
-XCTMain(tests)

--- a/Tests/ScoutTests/PathTests.swift
+++ b/Tests/ScoutTests/PathTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import Scout
+
+final class PathTests: XCTestCase {
+
+    // MARK: - Constants
+
+    let firstKey = "firstKey"
+    let secondKey = "secondKey"
+    let secondKeyWithIndex = "secondKey[1]"
+    let secondKeyWithdot = "second.key"
+    let secondKeyWithDotAndIndex = "second.key[1]"
+    let thirdKey = "thirdKey"
+    let thirdKeyWithDot = "third.Key"
+
+    // MARK: - Functions
+
+    func testSimpleKeys() throws {
+        let array: Path = [firstKey, secondKey, thirdKey]
+        let path = try Path(string: "\(firstKey).\(secondKey).\(thirdKey)")
+
+        XCTAssertTrue(path == array)
+    }
+
+    func testKeysWithIndexes() throws {
+        let array: Path = [firstKey, secondKey, 1, thirdKey]
+        let path = try Path(string: "\(firstKey).\(secondKeyWithIndex).\(thirdKey)")
+
+        XCTAssertTrue(path == array)
+    }
+
+    func testKeysWithBrackets() throws {
+        let array: Path = [firstKey, secondKey, 1, thirdKeyWithDot]
+        let path = try Path(string: "\(firstKey).\(secondKeyWithIndex).(\(thirdKeyWithDot))")
+
+        XCTAssertTrue(path == array)
+    }
+
+    func testKeysWithBracketsAndIndex() throws {
+        let array: Path = [firstKey, secondKeyWithdot, 1, thirdKey]
+        let path = try Path(string: "\(firstKey).(\(secondKeyWithDotAndIndex)).\(thirdKey)")
+
+        XCTAssertTrue(path == array)
+    }
+}

--- a/Tests/ScoutTests/XCTestManifests.swift
+++ b/Tests/ScoutTests/XCTestManifests.swift
@@ -1,9 +1,0 @@
-import XCTest
-
-#if !canImport(ObjectiveC)
-public func allTests() -> [XCTestCaseEntry] {
-    return [
-        testCase(SwiftyPlistTests.allTests)
-    ]
-}
-#endif


### PR DESCRIPTION
Changed the path with `->` separators to `.` separators. Also changed the array subscription by removing the separator (e.g. `array.[index]` to array[index]`) and the setting value operator from `:` to `=`.