### PR TITLE
Path init separator

### DIFF
--- a/Sources/Scout/Definitions/Path.swift
+++ b/Sources/Scout/Definitions/Path.swift
@@ -5,6 +5,8 @@ public typealias Path = [PathElement]
 
 public extension Path {
 
+    // MARK: - Computed properties
+
     var description: String {
         var description = ""
         forEach {
@@ -20,6 +22,8 @@ public extension Path {
         return description
     }
 
+    // MARK: - Initialization
+
     /**
      Instantiate a `Path` for a string representing path components separated with the separator.
 
@@ -34,16 +38,20 @@ public extension Path {
      - note: When enclosed with brackets, a path element will not be parsed. For example ```computer.(general.information).serial_number```
      will make the path ["computer", "general.information", "serial_number"]
 
+     - note: The following separators will not work: "[", "]", "(", ")".
+     When using a special caracter with [regular expression](https://developer.apple.com/documentation/foundation/nsregularexpression#1965589),
+     it is required to quote it with "\\".
+
     */
-    init(string: String, separator: String = ".") throws {
+    init(string: String, separator: String = "\\.") throws {
         var elements = [PathElement]()
 
-        let pattern = #"(?<=(^|\.))(\(.+\)|[^\.]+)(?=(\.|$))"#
-        let regex = try NSRegularExpression(pattern: pattern, options: [.anchorsMatchLines])
-        let indexPattern = #"(?<=\[)[0-9]+(?=\])"#
-        let indexRegex = try NSRegularExpression(pattern: indexPattern, options: [])
+        let splitRegexPattern = #"\(.+\)|[^\#(separator)]+"#
+        let indexRegexPattern = #"(?<=\[)[0-9]+(?=\])"#
+        let splitRegex = try NSRegularExpression(pattern: splitRegexPattern, options: [])
+        let indexRegex = try NSRegularExpression(pattern: indexRegexPattern, options: [])
 
-        let matches = regex.matches(in: string)
+        let matches = splitRegex.matches(in: string)
         for match in matches {
 
             // remove the brackets if any
@@ -71,9 +79,9 @@ public extension Path {
 
         self = elements
     }
-}
 
-extension Path {
+    // MARK: - Functions
+
     static func ==(lhs: Path, rhs: Path) -> Bool {
         guard lhs.count == rhs.count else { return false }
 

--- a/Tests/ScoutTests/PathTests.swift
+++ b/Tests/ScoutTests/PathTests.swift
@@ -10,8 +10,14 @@ final class PathTests: XCTestCase {
     let secondKeyWithIndex = "secondKey[1]"
     let secondKeyWithdot = "second.key"
     let secondKeyWithDotAndIndex = "second.key[1]"
+    let secondKeyWithFourthSeparator = "second$key"
+    let secondKeyWithFourthSeparatorAndIndex = "second$key[1]"
     let thirdKey = "thirdKey"
     let thirdKeyWithDot = "third.Key"
+
+    let secondSeparator = "->"
+    let thirdSeparator = "/"
+    let fourthSeparator = "\\$"
 
     // MARK: - Functions
 
@@ -39,6 +45,34 @@ final class PathTests: XCTestCase {
     func testKeysWithBracketsAndIndex() throws {
         let array: Path = [firstKey, secondKeyWithdot, 1, thirdKey]
         let path = try Path(string: "\(firstKey).(\(secondKeyWithDotAndIndex)).\(thirdKey)")
+
+        XCTAssertTrue(path == array)
+    }
+
+    func testSeparator1() throws {
+        let array: Path = [firstKey, secondKey, thirdKey]
+        let path = try Path(string: "\(firstKey)\(secondSeparator)\(secondKey)\(secondSeparator)\(thirdKey)", separator: secondSeparator)
+
+        XCTAssertTrue(path == array)
+    }
+
+    func testSeparator2() throws {
+        let array: Path = [firstKey, secondKey, thirdKey]
+        let path = try Path(string: "\(firstKey)\(thirdSeparator)\(secondKey)\(thirdSeparator)\(thirdKey)", separator: thirdSeparator)
+
+        XCTAssertTrue(path == array)
+    }
+
+    func testSeparator3() throws {
+        let array: Path = [firstKey, secondKey, thirdKey]
+        let path = try Path(string: "\(firstKey)$\(secondKey)$\(thirdKey)", separator: fourthSeparator)
+
+        XCTAssertTrue(path == array)
+    }
+
+    func testSeparator3WithBracketAndIndex() throws {
+        let array: Path = [firstKey, secondKeyWithFourthSeparator, 1, thirdKey]
+        let path = try Path(string: "\(firstKey)$(\(secondKeyWithFourthSeparatorAndIndex))$\(thirdKey)", separator: fourthSeparator)
 
         XCTAssertTrue(path == array)
     }


### PR DESCRIPTION
The separator was not used to parse the string in the Path initialisation.