### PR TITLE
Subscript errors improved

### DIFF
--- a/Sources/Scout/Definitions/Path.swift
+++ b/Sources/Scout/Definitions/Path.swift
@@ -11,14 +11,21 @@ public extension Path {
         var description = ""
         forEach {
             if let int = $0 as? Int {
+                // remove the point added automatically to a path element
+                if description.hasSuffix(".") {
+                    description.removeLast()
+                }
                 description.append("[\(int)]")
-                description.append("->")
             } else {
                 description.append(String(describing: $0))
             }
+
+            description.append(".")
         }
-        // remove the last arrow
-        description.removeLast(2)
+        // remove the last point if any
+        if description.hasSuffix(".") {
+            description.removeLast()
+        }
         return description
     }
 
@@ -65,6 +72,12 @@ public extension Path {
             // try to get the indexes if any
             if let indexMatch = indexMatches.first {
                 // we have a first index, so we can retrieve the array name and the first index
+                if indexMatch.range.lowerBound == 1 {
+                    // specific case: the root element is an array
+                    guard let index = Int(match[indexMatch.range]) else { throw PathExplorerError.invalidPathElement(match) }
+                    elements.append(index)
+                    continue
+                }
                 guard indexMatch.range.lowerBound > 1 else { throw PathExplorerError.invalidPathElement(match) }
                 // get the array name
                 let newMatch = String(match[0..<indexMatch.range.lowerBound - 1])
@@ -109,5 +122,12 @@ public extension Path {
             }
         }
         return isEqual
+    }
+
+    func appending(_ element: PathElement) -> Path {
+        var newPath = self
+        newPath.append(element)
+
+        return newPath
     }
 }

--- a/Sources/Scout/Definitions/PathExplorer.swift
+++ b/Sources/Scout/Definitions/PathExplorer.swift
@@ -31,6 +31,9 @@ where
 
     var format: DataFormat { get }
 
+    /// The path leading to the PathExplorer: firstKey.secondKey[index].thirdKey...
+    var readingPath: Path { get }
+
     // MARK: - Initialization
 
     init(data: Data) throws

--- a/Sources/Scout/Definitions/PathExplorerError.swift
+++ b/Sources/Scout/Definitions/PathExplorerError.swift
@@ -6,10 +6,10 @@ public enum PathExplorerError: LocalizedError {
     case valueConversionError(value: Any, type: String)
     case wrongValueForKey(value: Any, element: PathElement)
 
-    case dictionarySubscript(Any)
-    case subscriptMissingKey(String)
-    case arraySubscript(Any)
-    case subscriptWrongIndex(index: Int, arrayCount: Int)
+    case dictionarySubscript(Path)
+    case subscriptMissingKey(Path, String)
+    case arraySubscript(Path)
+    case subscriptWrongIndex(path: Path, index: Int, arrayCount: Int)
 
     case stringToDataConversionError
     case dataToStringConversionError
@@ -24,10 +24,10 @@ public enum PathExplorerError: LocalizedError {
         case .valueConversionError(let value, let type): return "Unable to convert the value \(value) to \(type)"
         case .wrongValueForKey(let value, let element): return "Cannot set `\(value)` to key/index #\(element)# which is a Dictionary or an Array"
 
-        case .dictionarySubscript(let key): return "The key #\(key)# is not a Dictionary"
-        case .subscriptMissingKey(let key): return "The key #\(key)# cannot be found in the Dictionary"
-        case .arraySubscript(let key): return "The key #\(key)# is not an Array"
-        case .subscriptWrongIndex(let index, let arrayCount): return "The index \(index) is not within the bounds of the Array: 0...\(arrayCount - 1)"
+        case .dictionarySubscript(let path): return "Cannot subscript the key at '\(path.description)' as it is not a Dictionary"
+        case .subscriptMissingKey(let path, let key): return "The key #\(key)# cannot be found in the Dictionary '\(path.description)'"
+        case .arraySubscript(let path): return "Cannot subscript the key at '\(path.description)' as is not an Array"
+        case .subscriptWrongIndex(let path, let index, let arrayCount): return "The index #\(index)# is not within the bounds of the Array (0...\(arrayCount - 1)) at '\(path.description)'"
 
         case .stringToDataConversionError: return "Unable to convert the input string into data"
         case .dataToStringConversionError: return "Unable to convert the data to a string"

--- a/Sources/Scout/Implementations/PathExplorerSerialization.swift
+++ b/Sources/Scout/Implementations/PathExplorerSerialization.swift
@@ -10,6 +10,8 @@ public struct PathExplorerSerialization<F: SerializationFormat> {
     var isDictionary: Bool { value is [String: Any] }
     var isArray: Bool { value is [Any] }
 
+    public var readingPath = Path()
+
     // MARK: - Initialization
 
     public init(data: Data) throws {
@@ -28,40 +30,45 @@ public struct PathExplorerSerialization<F: SerializationFormat> {
         self.value = value
     }
 
+    init(value: Any, path: Path) {
+        self.value = value
+        readingPath = path
+    }
+
     // MARK: - Functions
 
     // MARK: Get
 
     func get(for key: String) throws -> Self {
         guard let dict = value as? [String: Any] else {
-            throw PathExplorerError.dictionarySubscript(value)
+            throw PathExplorerError.dictionarySubscript(readingPath)
         }
 
         guard let childValue = dict[key] else {
-            throw PathExplorerError.subscriptMissingKey(key)
+            throw PathExplorerError.subscriptMissingKey(readingPath, key)
         }
 
-        return PathExplorerSerialization(value: childValue)
+        return PathExplorerSerialization(value: childValue, path: readingPath.appending(key))
     }
 
     /// - parameter negativeIndexEnabled: If set to `true`, it is possible to get the last element of an array with the index `-1`
     func get(at index: Int, negativeIndexEnabled: Bool = true) throws -> Self {
         guard let array = value as? [Any] else {
-            throw PathExplorerError.arraySubscript(value)
+            throw PathExplorerError.arraySubscript(readingPath)
         }
 
         if index == -1, negativeIndexEnabled {
             if array.isEmpty {
-                throw PathExplorerError.subscriptWrongIndex(index: index, arrayCount: array.count)
+                throw PathExplorerError.subscriptWrongIndex(path: readingPath, index: index, arrayCount: array.count)
             }
-            return PathExplorerSerialization(value: array[array.count - 1])
+            return PathExplorerSerialization(value: array[array.count - 1], path: readingPath.appending(index))
         }
 
         guard array.count > index, index >= 0 else {
-            throw PathExplorerError.subscriptWrongIndex(index: index, arrayCount: array.count)
+            throw PathExplorerError.subscriptWrongIndex(path: readingPath, index: index, arrayCount: array.count)
         }
 
-        return PathExplorerSerialization(value: array[index])
+        return PathExplorerSerialization(value: array[index], path: readingPath.appending(index))
     }
 
     /// - parameter negativeIndexEnabled: If set to `true`, it is possible to get the last element of an array with the index `-1`
@@ -91,11 +98,11 @@ public struct PathExplorerSerialization<F: SerializationFormat> {
 
     mutating func set(key: String, to newValue: Any) throws {
         guard var dict = value as? [String: Any] else {
-            throw PathExplorerError.dictionarySubscript(value)
+            throw PathExplorerError.dictionarySubscript(readingPath)
         }
 
         guard dict[key] != nil else {
-            throw PathExplorerError.subscriptMissingKey(key)
+            throw PathExplorerError.subscriptMissingKey(readingPath, key)
         }
 
         dict[key] = newValue
@@ -104,7 +111,7 @@ public struct PathExplorerSerialization<F: SerializationFormat> {
 
     mutating func set(index: Int, to newValue: Any) throws {
         guard var array = value as? [Any] else {
-            throw PathExplorerError.arraySubscript(value)
+            throw PathExplorerError.arraySubscript(readingPath)
         }
 
         if index == -1 {
@@ -114,7 +121,7 @@ public struct PathExplorerSerialization<F: SerializationFormat> {
         }
 
         guard array.count > index, index >= 0 else {
-            throw PathExplorerError.subscriptWrongIndex(index: index, arrayCount: array.count)
+            throw PathExplorerError.subscriptWrongIndex(path: readingPath, index: index, arrayCount: array.count)
         }
 
         array[index] = newValue
@@ -169,11 +176,11 @@ public struct PathExplorerSerialization<F: SerializationFormat> {
 
     mutating func change(key: String, nameTo newKeyName: String) throws {
         guard var dict = value as? [String: Any] else {
-            throw PathExplorerError.dictionarySubscript(String(describing: value))
+            throw PathExplorerError.dictionarySubscript(readingPath)
         }
 
         guard let childValue = dict[key] else {
-            throw PathExplorerError.subscriptMissingKey(key)
+            throw PathExplorerError.subscriptMissingKey(readingPath, key)
         }
 
         dict[newKeyName] = childValue
@@ -214,11 +221,11 @@ public struct PathExplorerSerialization<F: SerializationFormat> {
     mutating func delete(element: PathElement) throws {
         if let key = element as? String {
             guard var dict = value as? [String: Any] else {
-                throw PathExplorerError.dictionarySubscript(value)
+                throw PathExplorerError.dictionarySubscript(readingPath)
             }
 
             guard dict[key] != nil else {
-                throw PathExplorerError.subscriptMissingKey(key)
+                throw PathExplorerError.subscriptMissingKey(readingPath, key)
             }
 
             dict.removeValue(forKey: key)
@@ -226,12 +233,12 @@ public struct PathExplorerSerialization<F: SerializationFormat> {
 
         } else if let index = element as? Int {
             guard var array = value as? [Any] else {
-                throw PathExplorerError.arraySubscript(value)
+                throw PathExplorerError.arraySubscript(readingPath)
             }
 
             if index == -1 {
                 guard !array.isEmpty else {
-                    throw PathExplorerError.subscriptWrongIndex(index: index, arrayCount: array.count)
+                    throw PathExplorerError.subscriptWrongIndex(path: readingPath, index: index, arrayCount: array.count)
                 }
                 array.removeLast()
                 value = array
@@ -239,7 +246,7 @@ public struct PathExplorerSerialization<F: SerializationFormat> {
             }
 
             guard 0 <= index, index < array.count else {
-                throw PathExplorerError.subscriptWrongIndex(index: index, arrayCount: array.count)
+                throw PathExplorerError.subscriptWrongIndex(path: readingPath, index: index, arrayCount: array.count)
             }
 
             array.remove(at: index)
@@ -285,14 +292,14 @@ public struct PathExplorerSerialization<F: SerializationFormat> {
 
         if var dict = value as? [String: Any] {
             guard let key = element as? String else {
-                throw PathExplorerError.dictionarySubscript(value)
+                throw PathExplorerError.dictionarySubscript(readingPath)
             }
             dict[key] = newValue
             value = dict
 
         } else if var array = value as? [Any] {
             guard let index = element as? Int else {
-                throw PathExplorerError.arraySubscript(value)
+                throw PathExplorerError.arraySubscript(readingPath)
             }
 
             if index == -1 || array.isEmpty {

--- a/Sources/ScoutCLT/RuntimeError.swift
+++ b/Sources/ScoutCLT/RuntimeError.swift
@@ -5,10 +5,10 @@ enum RuntimeError: LocalizedError {
     case noValueAt(path: String)
     case unknownFormat(String)
 
-    var desription: String {
+    var errorDescription: String {
         switch self {
         case .invalidData(let description): return description
-        case .noValueAt(let path): return "No value at the path \(path)"
+        case .noValueAt(let path): return "No single value at '\(path)'. Either Dictionary or Array to subscript."
         case .unknownFormat(let description): return description
         }
     }

--- a/Tests/ScoutTests/PathExplorerSerializationTests.swift
+++ b/Tests/ScoutTests/PathExplorerSerializationTests.swift
@@ -18,6 +18,8 @@ final class PathExplorerSerializationTests: XCTestCase {
         let animals = Animals()
     }
 
+    let ducks = ["Riri", "Fifi", "Loulou"]
+
     // MARK: - Functions
 
     func testInit() throws {
@@ -82,6 +84,16 @@ final class PathExplorerSerializationTests: XCTestCase {
         try plist.set(path, to: newValue)
 
         XCTAssertEqual(try plist.get(path).string, newValue)
+    }
+
+    func testDecodeRootArray() throws {
+        let data = try PropertyListEncoder().encode(ducks)
+        let plist = try PathExplorerSerialization<PlistFormat>(data: data)
+        let second: [PathElement] = [1]
+        let last: [PathElement] = [-1]
+
+        XCTAssertEqual(try plist.get(second).string, "Fifi")
+        XCTAssertEqual(try plist.get(last).string, "Loulou")
     }
 
     func testSetKeyName() throws {

--- a/Tests/ScoutTests/PathTests.swift
+++ b/Tests/ScoutTests/PathTests.swift
@@ -100,4 +100,11 @@ final class PathTests: XCTestCase {
 
         XCTAssertTrue(path == array)
     }
+
+    func testRootElementArray() throws {
+        let array: Path = [1, firstKey, secondKey]
+        let path = try Path(string: "[1].\(firstKey).\(secondKey)")
+
+        XCTAssertTrue(path == array)
+    }
 }


### PR DESCRIPTION
With the added `readingPath` property, it is possible to precisely trace where the error occurs in the given path.

Also fixed a bug preventing the initialization of a Path if the root element was an array.