### PR TITLE
[#51] Custom colors in a plist file

### DIFF
--- a/Sources/ScoutCLT/ColorDelegates/ColorFile.swift
+++ b/Sources/ScoutCLT/ColorDelegates/ColorFile.swift
@@ -1,0 +1,29 @@
+struct JsonColors: Codable {
+    var punctuation: Int?
+    var keyName: Int?
+    var keyValue: Int?
+}
+
+struct PlistColors: Codable {
+    var tag: Int?
+    var keyName: Int?
+    var keyValue: Int?
+    var header: Int?
+    var comment: Int?
+}
+
+struct XmlColors: Codable {
+    var punctuation: Int?
+    var openingTag: Int?
+    var closingTag: Int?
+    var key: Int?
+    var header: Int?
+    var comment: Int?
+}
+
+/// Plist file to specify custom colors
+struct ColorFile: Codable {
+    var json: JsonColors?
+    var plist: PlistColors?
+    var xml: XmlColors?
+}

--- a/Sources/ScoutCLT/ColorDelegates/JSONInjectorDelegate.swift
+++ b/Sources/ScoutCLT/ColorDelegates/JSONInjectorDelegate.swift
@@ -1,0 +1,36 @@
+import Lux
+
+final class JSONInjectorColorDelegate: JSONDelegate {
+
+    // MARK: - Properties
+
+    let colors: JsonColors
+
+    // MARK: - Initialisation
+
+    init(colors: JsonColors) {
+        self.colors = colors
+    }
+
+    required init() {
+        fatalError("init() has not been implemented")
+    }
+
+    // MARK: - Functions
+
+    override func injection(for category: JSONCategory, type: TextType) -> String {
+        var colorCode: Int?
+
+        switch category {
+        case .punctuation: colorCode = colors.punctuation
+        case .keyName: colorCode = colors.keyName
+        case .keyValue: colorCode = colors.punctuation
+        }
+
+        if let code = colorCode {
+            return String.colorPrefix(code)
+        } else {
+            return super.injection(for: category, type: type)
+        }
+    }
+}

--- a/Sources/ScoutCLT/ColorDelegates/PlistInjectorColorDelegate.swift
+++ b/Sources/ScoutCLT/ColorDelegates/PlistInjectorColorDelegate.swift
@@ -1,0 +1,38 @@
+import Lux
+
+final class PlistInjectorColorDelegate: PlistDelegate {
+
+    // MARK: - Properties
+
+    let colors: PlistColors
+
+    // MARK: - Initialisation
+
+    init(colors: PlistColors) {
+        self.colors = colors
+    }
+
+    required init() {
+        fatalError("init() has not been implemented")
+    }
+
+    // MARK: - Functions
+
+    override func injection(for category: PlistCategory, type: TextType) -> String {
+        var colorCode: Int?
+
+        switch category {
+        case .tag: colorCode = colors.tag
+        case .keyName: colorCode = colors.keyName
+        case .keyValue: colorCode = colors.keyValue
+        case .comment: colorCode = colors.comment
+        case .header: colorCode = colors.header
+        }
+
+        if let code = colorCode {
+            return String.colorPrefix(code)
+        } else {
+            return super.injection(for: category, type: type)
+        }
+    }
+}

--- a/Sources/ScoutCLT/ColorDelegates/XMLInjectorColorDelegate.swift
+++ b/Sources/ScoutCLT/ColorDelegates/XMLInjectorColorDelegate.swift
@@ -1,0 +1,39 @@
+import Lux
+
+final class XMLInjectorColorDelegate: XMLEnhancedDelegate {
+
+    // MARK: - Properties
+
+    let colors: XmlColors
+
+    // MARK: - Initialisation
+
+    init(colors: XmlColors) {
+        self.colors = colors
+    }
+
+    required init() {
+        fatalError("init() has not been implemented")
+    }
+
+    // MARK: - Functions
+
+    override func injection(for category: XMLEnhancedCategory, type: TextType) -> String {
+        var colorCode: Int?
+
+        switch category {
+        case .openingTag: colorCode = colors.openingTag
+        case .closingTag: colorCode = colors.closingTag
+        case .punctuation: colorCode = colors.punctuation
+        case .key: colorCode = colors.key
+        case .comment: colorCode = colors.comment
+        case .header: colorCode = colors.header
+        }
+
+        if let code = colorCode {
+            return String.colorPrefix(code)
+        } else {
+            return super.injection(for: category, type: type)
+        }
+    }
+}

--- a/Sources/ScoutCLT/Extensions/String+Extensions.swift
+++ b/Sources/ScoutCLT/Extensions/String+Extensions.swift
@@ -12,9 +12,13 @@ extension String {
         return userHomeDirectory + pathAfterHome
     }
 
-    var reset: String { "\u{001B}[0m" }
-    var bold: String { "\u{001B}[1m\(self)\u{001B}[22m" }
-    var validation: String { "\u{001B}[32m\(self)\u{001B}[39m"}
-    var error: String { "\u{001B}[91m\(self)\u{001B}[39m"}
+    static var prefix: String { "\u{001B}[" }
+    static var colorReset: String { "\(Self.prefix)39m" }
+    static var reset: String { "\(Self.prefix)0m" }
+
+    var bold: String { "\(Self.prefix)1;39m\(self)\(Self.prefix)22m" }
+    var error: String { "\(Self.colorPrefix(91))\(self)\(Self.colorReset)"}
+
+    static func colorPrefix(_ code: Int) -> String { "\(prefix)38;5;\(code)m" }
 
 }

--- a/Sources/ScoutCLT/ReadCommand.swift
+++ b/Sources/ScoutCLT/ReadCommand.swift
@@ -108,15 +108,33 @@ struct ReadCommand: ParsableCommand {
         if let json = try? PathExplorerFactory.make(Json.self, from: data) {
             let key = try json.get(path)
             value = key.stringValue != "" ? key.stringValue : key.description
-            injector = JSONInjector(type: .plain)
+
+            let jsonInjector = JSONInjector(type: .plain)
+            if let colors = try ScoutCommand.getColorFile()?.json {
+                jsonInjector.delegate = JSONInjectorColorDelegate(colors: colors)
+            }
+            injector = jsonInjector
+
         } else if let plist = try? PathExplorerFactory.make(Plist.self, from: data) {
             let key = try plist.get(path)
             value = key.stringValue != "" ? key.stringValue : key.description
-            injector = PlistInjector(type: .plain)
+
+            let plistInjector = PlistInjector(type: .plain)
+            if let colors = try ScoutCommand.getColorFile()?.plist {
+                plistInjector.delegate = PlistInjectorColorDelegate(colors: colors)
+            }
+            injector = plistInjector
+
         } else if let xml = try? PathExplorerFactory.make(Xml.self, from: data) {
             let key = try xml.get(path)
             value = key.stringValue != "" ? key.stringValue : key.description
-            injector = XMLEnhancedInjector(type: .plain)
+
+            let xmlInjector = XMLEnhancedInjector(type: .plain)
+            if let colors = try ScoutCommand.getColorFile()?.xml {
+                xmlInjector.delegate = XMLInjectorColorDelegate(colors: colors)
+            }
+            injector = xmlInjector
+
         } else {
             if let filePath = inputFilePath {
                 throw RuntimeError.unknownFormat("The format of the file at \(filePath) is not recognized")


### PR DESCRIPTION
- Let the user specify custom colors in the file at *~/scout/Colors.plist*
- Updated the style specification in the string extension