### PR TITLE
[#81] Path element refactoring

### DIFF
--- a/Sources/Scout/Definitions/PathElement.swift
+++ b/Sources/Scout/Definitions/PathElement.swift
@@ -1,7 +1,39 @@
 import Foundation
 
-/// Components to subscript a `PathExplorer`
-public protocol PathElement: Codable {}
+/// Store the possible elements that can be used to subscript a `PathExplorer`
+public enum PathElement: Equatable {
+    case key(String)
+    case index(Int)
 
-extension String: PathElement {}
-extension Int: PathElement {}
+    var key: String? {
+        if case let .key(key) = self {
+            return key
+        } else {
+            return nil
+        }
+    }
+
+    var index: Int? {
+        if case let .index(index) = self {
+            return index
+        } else {
+            return nil
+        }
+    }
+}
+
+extension PathElement: ExpressibleByStringLiteral {
+    public typealias StringLiteralType = String
+
+    public init(stringLiteral: String) {
+        self = .key(stringLiteral)
+    }
+}
+
+extension PathElement: ExpressibleByIntegerLiteral {
+    public typealias IntegerLiteralType = Int
+
+    public init(integerLiteral: Int) {
+        self = .index(integerLiteral)
+    }
+}

--- a/Sources/Scout/Definitions/PathElementRepresentable.swift
+++ b/Sources/Scout/Definitions/PathElementRepresentable.swift
@@ -1,0 +1,31 @@
+/// Protocol to allow to subscript a `PathExplorer` without using directly the `PathElement` enum.
+///
+/// As `PathElement` already conforms to `ExpressibleByStringLiteral` and `ExpressibleByIntegerLiteral`,
+/// it is possible to instantiate a Path without the need of using the `PathElementRepresentable` protocol:
+/// ```
+/// let path: Path = ["people", "Tom", "hobbies", 1]
+/// ```
+/// But the "Expressible" protocols do not allow to do the same with variables.
+/// Thus, using `PathElementRepresentable` allows to instantiate a Path from a mix of Strings and Integers variables:
+/// ```
+/// let firstKey = "people"
+/// let secondKey = "Tom"
+/// let thirdKey = "hobbies"
+/// let index = 1
+/// let path: Path = [firstKey, secondKey, thirdKey, index]
+/// ```
+public protocol PathElementRepresentable {
+    var pathValue: PathElement { get }
+}
+
+extension String: PathElementRepresentable {
+    public var pathValue: PathElement { .key(self) }
+}
+
+extension Int: PathElementRepresentable {
+    public var pathValue: PathElement { .index(self) }
+}
+
+extension PathElement: PathElementRepresentable {
+    public var pathValue: PathElement { self }
+}

--- a/Sources/Scout/Definitions/PathExplorer.swift
+++ b/Sources/Scout/Definitions/PathExplorer.swift
@@ -64,14 +64,14 @@ where
     /// Set the value of the key at the given path, specified as array
     /// - Throws: If the path is invalid (e.g. a key does not exist in a dictionary, or indicating an index on a non-array key)
     /// - note: The type of the `value` parameter will be automatically inferred. To force the `value`type, use the parameter `as type`
-    mutating func set(_ path: [PathElement], to newValue: Any) throws
+    mutating func set(_ path: Path, to newValue: Any) throws
 
     /// Set the value of the key at the given path, specified as array
     /// - parameter type: Try to force the conversion of the `value` parameter to the given type,
     /// throwing an error if the conversion is not possible
     /// - Throws: If the path is invalid (e.g. a key does not exist in a dictionary, or indicating an index on a non-array key)
     /// - note: The type of the `value` parameter will be automatically inferred.
-    mutating func set<Type: KeyAllowedType>(_ path: [PathElement], to newValue: Any, as type: KeyType<Type>) throws
+    mutating func set<Type: KeyAllowedType>(_ path: Path, to newValue: Any, as type: KeyType<Type>) throws
 
     /// Set the value of the key at the given path, specified as array
     /// - Throws: If the path is invalid (e.g. a key does not exist in a dictionary, or indicating an index on a non-array key)

--- a/Sources/Scout/Implementations/PathExplorerSerialization+PathExplorer.swift
+++ b/Sources/Scout/Implementations/PathExplorerSerialization+PathExplorer.swift
@@ -57,7 +57,7 @@ extension PathExplorerSerialization: PathExplorer {
 
     // MARK: Set
 
-    public mutating func set(_ path: [PathElement], to newValue: Any) throws {
+    public mutating func set(_ path: Path, to newValue: Any) throws {
         try set(path, to: newValue, as: .automatic)
     }
 

--- a/Sources/Scout/Implementations/PathExplorerXML+PathExplorer.swift
+++ b/Sources/Scout/Implementations/PathExplorerXML+PathExplorer.swift
@@ -20,7 +20,7 @@ extension PathExplorerXML: PathExplorer {
         var currentPathExplorer = self
 
         try pathElements.forEach {
-            currentPathExplorer = try currentPathExplorer.get(pathElement: $0)
+            currentPathExplorer = try currentPathExplorer.get(pathElement: $0.pathValue)
         }
 
         return currentPathExplorer
@@ -41,7 +41,7 @@ extension PathExplorerXML: PathExplorer {
 
     // MARK: Set
 
-    public mutating func set<Type>(_ path: [PathElement], to newValue: Any, as type: KeyType<Type>) throws where Type: KeyAllowedType {
+    public mutating func set<Type>(_ path: Path, to newValue: Any, as type: KeyType<Type>) throws where Type: KeyAllowedType {
         try set(path, to: newValue)
     }
 

--- a/Tests/ScoutTests/PathTests.swift
+++ b/Tests/ScoutTests/PathTests.swift
@@ -7,6 +7,7 @@ final class PathTests: XCTestCase {
 
     let firstKey = "firstKey"
     let secondKey = "secondKey"
+    let index = 1
     let secondKeyWithIndex = "secondKey[1]"
     let secondKeyWithNegativeIndex = "secondKey[-1]"
     let secondKeyWithdot = "second.key"
@@ -24,6 +25,13 @@ final class PathTests: XCTestCase {
 
     // MARK: - Functions
 
+    func testEqual() throws {
+        let path1: Path = [firstKey, secondKey, thirdKey]
+        let path2: Path = [firstKey, secondKey, thirdKey]
+
+        XCTAssertTrue(path1 == path2)
+    }
+
     func testSimpleKeys() throws {
         let array: Path = [firstKey, secondKey, thirdKey]
         let path = try Path(string: "\(firstKey).\(secondKey).\(thirdKey)")
@@ -32,21 +40,21 @@ final class PathTests: XCTestCase {
     }
 
     func testKeysWithIndex() throws {
-        let array: Path = [firstKey, secondKey, 1, thirdKey]
+        let array: Path = [firstKey, secondKey, index, thirdKey]
         let path = try Path(string: "\(firstKey).\(secondKeyWithIndex).\(thirdKey)")
 
         XCTAssertTrue(path == array)
     }
 
     func testKeysWithNegativeIndex() throws {
-        let array: Path = [firstKey, secondKey, -1, thirdKey]
+        let array: Path = [firstKey, secondKey, -index, thirdKey]
         let path = try Path(string: "\(firstKey).\(secondKeyWithNegativeIndex).\(thirdKey)")
 
         XCTAssertTrue(path == array)
     }
 
     func testKeysWithBrackets() throws {
-        let array: Path = [firstKey, secondKey, 1, thirdKeyWithDot]
+        let array: Path = [firstKey, secondKey, index, thirdKeyWithDot]
         let path = try Path(string: "\(firstKey).\(secondKeyWithIndex).(\(thirdKeyWithDot))")
 
         XCTAssertTrue(path == array)
@@ -60,14 +68,14 @@ final class PathTests: XCTestCase {
     }
 
     func testNestedArray() throws {
-        let array: Path = [firstKey, secondKey, 1, 0, thirdKey]
+        let array: Path = [firstKey, secondKey, index, 0, thirdKey]
         let path = try Path(string: "\(firstKey).\(secondKeyWithNestedArray).\(thirdKey)")
 
         XCTAssertTrue(path == array)
     }
 
     func testNestedArrayTwoLevels() throws {
-        let array: Path = [firstKey, secondKey, 1, 0, 2, thirdKey]
+        let array: Path = [firstKey, secondKey, index, 0, 2, thirdKey]
         let path = try Path(string: "\(firstKey).\(secondKeyWithTwoNestedArrays).\(thirdKey)")
 
         XCTAssertTrue(path == array)
@@ -95,7 +103,7 @@ final class PathTests: XCTestCase {
     }
 
     func testSeparator3WithBracketAndIndex() throws {
-        let array: Path = [firstKey, secondKeyWithFourthSeparator, 1, thirdKey]
+        let array: Path = [firstKey, secondKeyWithFourthSeparator, index, thirdKey]
         let path = try Path(string: "\(firstKey)$(\(secondKeyWithFourthSeparatorAndIndex))$\(thirdKey)", separator: fourthSeparator)
 
         XCTAssertTrue(path == array)


### PR DESCRIPTION
Path element is now an enum. To still allow the initialisation of a Path from an array of Strings an Ints, the protocol PathElementRepresentable abstracts PathElement. Thus, it’s required to use the element.pathValue when dealing with PathelEments.

Closes #81 