### PR TITLE
Setting a value now calls the convert function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file. `Scout` adheres to [Semantic Versioning](http://semver.org).
 
 ---
+## [1.3.2](https://github.com/ABridoux/scout/tree/1.3.1) (09/08/2020)
+
+### Fixed
+- Setting a value was always writing a String rather than inferring the type for JSON and Plist [#96]
+
 ## [1.3.1](https://github.com/ABridoux/scout/tree/1.3.1) (27/07/2020)
 
 ### Added

--- a/Sources/Scout/Constants/Version.swift
+++ b/Sources/Scout/Constants/Version.swift
@@ -4,5 +4,5 @@
 // MIT license, see LICENSE file for details
 
 public struct Version {
-    public static let current = "1.3.1"
+    public static let current = "1.3.2"
 }

--- a/Sources/Scout/Implementations/Serialization/PathExplorerSerialization+Set.swift
+++ b/Sources/Scout/Implementations/Serialization/PathExplorerSerialization+Set.swift
@@ -49,6 +49,8 @@ extension PathExplorerSerialization {
     public mutating func set<Type: KeyAllowedType>(_ path: Path, to newValue: Any, as type: KeyType<Type>) throws {
         guard !path.isEmpty else { return }
 
+        let newValue = try convert(newValue, to: type)
+
         let (pathExplorers, path, lastElement) = try getExplorers(from: path)
 
         guard var currentExplorer = pathExplorers.last else {

--- a/Sources/Scout/Implementations/Serialization/PathExplorerSerialization.swift
+++ b/Sources/Scout/Implementations/Serialization/PathExplorerSerialization.swift
@@ -138,7 +138,7 @@ public struct PathExplorerSerialization<F: SerializationFormat>: PathExplorer {
         try add(newValue, at: Path(path), as: .automatic)
     }
 
-    public mutating func add<Type>(_ newValue: Any, at path: PathElementRepresentable..., as type: KeyType<Type>) throws where Type: KeyAllowedType {
+    public mutating func add<Type: KeyAllowedType>(_ newValue: Any, at path: PathElementRepresentable..., as type: KeyType<Type>) throws {
         try add(newValue, at: Path(path), as: type)
     }
 


### PR DESCRIPTION
### Fixed
- Setting a value was always writing a String rather than inferring the type for JSON and Plist [#96]