### PR TITLE
[#100] Completion script installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,21 +135,23 @@ It will **download the notarized executable** from the [latest release](https://
 
 You can download the [latest version of the executable](https://github.com/ABridoux/scout/releases/latest/download/scout.zip) from the [releases](https://github.com/ABridoux/scout/releases). Note that the **executable is notarized**. Also, a notarized [scout package](https://github.com/ABridoux/scout/releases/latest/download/scout.pkg) is provided.
 
-After having unzipped the file, you can install it if you want to:
+After having unzipped the file, you can install it if you want to. The second line lets you install the script to auto-complete the commands.
 
 ```bash
-install scout /usr/local/bin/ 
+$ install scout /usr/local/bin/ 
+$ scout install-completion-script
 ```
 
 Here is a command which downloads the latest version of the program and install it in */usr/local/bin*. 
-Run it to download and install the latest version of the program. It erases the current version you may have.
+Run it to download and install the latest version of the program. It erases the current version you may have. Uncomment the last line to install the script to auto-complete the commands.
 
 ```bash
 curl -LO https://github.com/ABridoux/scout/releases/latest/download/scout.zip && \
 unzip scout.zip && \
 rm scout.zip && \
 install scout /usr/local/bin && \
-rm scout
+rm scout && \
+scout install-completion-script
 ```
 
 ##### Note
@@ -158,12 +160,13 @@ rm scout
 
 #### Git
 
-Use the following lines to clone the repository and to install **scout** (requires Swift 5.2 toolchain to be installed). You can check the *Makefile* to see the commands used to build and install the executable.
+Use the following lines to clone the repository and to install **scout** (requires Swift 5.2 toolchain to be installed). You can check the *Makefile* to see the commands used to build and install the executable. The last line is optional and lets you install the script to auto-complete the commands.
 
 ```bash
 $ git clone https://github.com/ABridoux/scout
 $ cd scout
 $ make
+$ scout install-completion-script
 ```
 
 The program should be install in */usr/local/bin*. You can then remove the repository if you do not want to keep it:

--- a/Sources/ScoutCLT/Main/DocCommand.swift
+++ b/Sources/ScoutCLT/Main/DocCommand.swift
@@ -69,7 +69,7 @@ struct HomeDocumentation: Documentation {
     \u{001B}[0;0m
 
     Here is an overview of scout subcommands: \(Command.documentationDescription).
-    To get more insights for a specific command, please type `scout doc \("[command]".mainColor)`.
+    To get more insights for a specific command, please type `scout doc -c \("[command]".mainColor)`.
 
     To indicate what value to target, a reading path should be indicated.
     \(ArgumentHelp.readingPath.discussion)

--- a/Sources/ScoutCLT/Main/InstallCompletionScriptCommand.swift
+++ b/Sources/ScoutCLT/Main/InstallCompletionScriptCommand.swift
@@ -1,0 +1,118 @@
+//
+// Scout
+// Copyright (c) Alexis Bridoux 2020
+// MIT license, see LICENSE file for details
+
+import Foundation
+import ArgumentParser
+
+private let argumentParserDocumentation = "https://github.com/apple/swift-argument-parser/blob/master/Documentation/07%20Completion%20Scripts.md"
+
+struct InstallCompletionScriptCommand: ParsableCommand {
+
+    // MARK: - Constants
+
+    static let configuration = CommandConfiguration(
+        commandName: "install-completion-script",
+        abstract: "Install Scout completion script in the right directoy",
+        discussion: "See \(argumentParserDocumentation)",
+        shouldDisplay: false)
+
+    var fileManager: FileManager { .default }
+    static let homeDirectory = FileManager.default.homeDirectoryForCurrentUser
+
+    // MARK: - Functions
+
+    func run() throws {
+
+        guard let shell = CompletionShell.autodetected() else {
+            throw RuntimeError.completionScriptInstallation(description: "Unable to find the prefered shell")
+        }
+
+        var compShell: CompShell
+
+        switch shell {
+        case .zsh:
+            if fileManager.fileExists(atPath: OhMyZsh.directory.path) { // oh my Zsh
+                compShell = OhMyZsh()
+            } else if fileManager.fileExists(atPath: Zsh.directory.path) { // zsh
+                compShell = Zsh()
+            } else {
+                throw RuntimeError.completionScriptInstallation(description: "Unable to find \(OhMyZsh.name) or \(Zsh.name) directory. Please refer to \(argumentParserDocumentation)")
+            }
+
+        case .bash:
+            if fileManager.fileExists(atPath: BashCompletion.completionsDirectory.path) { // bash completion
+                compShell = BashCompletion()
+            } else { // bash
+                compShell = Bash()
+            }
+
+        default:
+            throw RuntimeError.completionScriptInstallation(description: "Unable to find the prefered shell. Please refer to \(argumentParserDocumentation)")
+        }
+
+        let shellType = type(of: compShell)
+        print("\(shellType.name) detected. Installing the completion script at \(shellType.completionsDirectory.path)")
+        try installScript(for: compShell)
+    }
+
+    private func installScript(for shell: CompShell) throws {
+        let shellType = type(of: shell)
+
+        if !fileManager.fileExists(atPath: shellType.completionsDirectory.path) {
+            print("\(shellType.name) completion directory not found. Creating it at \(shellType.completionsDirectory.path)...")
+            try fileManager.createDirectory(at: shellType.completionsDirectory, withIntermediateDirectories: false)
+        }
+
+        if fileManager.fileExists(atPath: shellType.completionScript.path) {
+            print("Completion script found. Re-installing it...")
+            try fileManager.removeItem(at: shellType.completionScript)
+        }
+
+        let script = ScoutCommand.completionScript(for: shellType.shell)
+        guard let data = script.data(using: .utf8) else {
+            throw RuntimeError.completionScriptInstallation(description: "Unable to convert the script to valid data")
+        }
+
+        fileManager.createFile(atPath: shellType.completionScript.path, contents: data)
+        print("Re/Installed completion script.")
+    }
+}
+
+private protocol CompShell {
+    static var shell: CompletionShell { get }
+    static var name: String { get }
+    static var completionsDirectory: URL { get }
+    static var completionScript: URL { get }
+}
+
+private struct OhMyZsh: CompShell {
+    static let shell = CompletionShell.zsh
+    static let name = "Oh My Zsh"
+    static let directory = InstallCompletionScriptCommand.homeDirectory.appendingPathComponent(".oh-my-zsh")
+    static let completionsDirectory = directory.appendingPathComponent("completions")
+    static let completionScript = completionsDirectory.appendingPathComponent("_scout")
+}
+
+private struct Zsh: CompShell {
+    static let shell = CompletionShell.zsh
+    static let name = "Zsh"
+    static let directory = InstallCompletionScriptCommand.homeDirectory.appendingPathComponent(".zsh")
+    static let completionsDirectory = directory.appendingPathComponent("completion")
+    static let completionScript = completionsDirectory.appendingPathComponent("scout.sh")
+}
+
+private struct BashCompletion: CompShell {
+    static let shell = CompletionShell.bash
+    static let name = "Bash Completion"
+    static let completionsDirectory = URL(fileURLWithPath: "/usr/local/etc/bash_completion.d")
+    static let completionScript = completionsDirectory.appendingPathComponent("_scout")
+}
+
+private struct Bash: CompShell {
+    static let shell = CompletionShell.bash
+    static let name = "Bash"
+    static let completionsDirectory = InstallCompletionScriptCommand.homeDirectory.appendingPathComponent(".bash_completions")
+    static let completionScript = completionsDirectory.appendingPathComponent("scout.bash")
+}

--- a/Sources/ScoutCLT/Main/ScoutCommand.swift
+++ b/Sources/ScoutCLT/Main/ScoutCommand.swift
@@ -24,6 +24,8 @@ Written by Alexis Bridoux.
 
 struct ScoutCommand: ParsableCommand {
 
+    // MARK: - Constants
+
     static let configuration = CommandConfiguration(
             commandName: "scout",
             abstract: abstract,
@@ -34,8 +36,11 @@ struct ScoutCommand: ParsableCommand {
                 DeleteCommand.self,
                 AddCommand.self,
                 DocCommand.self,
-                VersionCommand.self],
+                VersionCommand.self,
+                InstallCompletionScriptCommand.self],
             defaultSubcommand: ReadCommand.self)
+
+    // MARK: - Functions
 
     static func output<T: PathExplorer>(_ output: String?, dataWith pathExplorer: T, verbose: Bool, colorise: Bool) throws {
         if let output = output?.replacingTilde {

--- a/Sources/ScoutCLT/Models/RuntimeError.swift
+++ b/Sources/ScoutCLT/Models/RuntimeError.swift
@@ -9,12 +9,14 @@ enum RuntimeError: LocalizedError {
     case invalidData(String)
     case noValueAt(path: String)
     case unknownFormat(String)
+    case completionScriptInstallation(description: String)
 
     var errorDescription: String? {
         switch self {
         case .invalidData(let description): return description
         case .noValueAt(let path): return "No value at '\(path)'"
         case .unknownFormat(let description): return description
+        case .completionScriptInstallation(let description): return "Error while installating the completion script. \(description)"
         }
     }
 }


### PR DESCRIPTION
Scout sub-command `InstallCompletionScriptCommand` to install or re-install the completion script int the right folder depending on the shell and the installed plugins.

Closes #100 