### PR TITLE
[#62] Fold dictionaries and arrays at a certain level

### DIFF
--- a/Sources/Scout/Definitions/PathExplorer+Extensions.swift
+++ b/Sources/Scout/Definitions/PathExplorer+Extensions.swift
@@ -54,6 +54,12 @@ extension PathExplorer {
         default: return false
         }
     }
+
+    /// Use to name the single key when folding a dictionary
+    static var foldedKey: String { "Folded" }
+
+    /// Use to replace the content of a dicionary or array when folding it
+    static var foldedMark: String { "~~SCOUT_FOLDED~~" }
 }
 
 // MARK: Data validation

--- a/Sources/Scout/Definitions/PathExplorer.swift
+++ b/Sources/Scout/Definitions/PathExplorer.swift
@@ -361,4 +361,8 @@ where
 
     func exportData() throws -> Data
     func exportString() throws -> String
+
+    /// Replace the group values (array or dictionaries) sub values by a unique one
+    /// holding a fold mark to be replaced when exporting the string
+    mutating func fold(upTo level: Int)
 }

--- a/Sources/Scout/Definitions/SerializationFormat.swift
+++ b/Sources/Scout/Definitions/SerializationFormat.swift
@@ -7,11 +7,24 @@ import Foundation
 
 /// Format which allows serialization
 public protocol SerializationFormat {
+
+    /// Regular expression pattern to find all the scout folded marks in the exported string
+    static var foldedRegexPattern: String { get }
+
     static func serialize(data: Data) throws -> Any
     static func serialize(value: Any) throws -> Data
 }
 
 public struct PlistFormat: SerializationFormat {
+
+    public static var foldedRegexPattern: String {
+        let foldedMark = PathExplorerSerialization<Self>.foldedMark
+        let foldedKey = PathExplorerSerialization<Self>.foldedKey
+
+        return #"(?<=<array>)\s*<string>\#(foldedMark)</string>\s*(?=</array>)"# // array
+        + #"|(?<=<dict>)\s*<key>\#(foldedKey)</key>\s*<string>\#(foldedMark)</string>\s*(?=</dict>)"# // dict
+    }
+
     public static func serialize(data: Data) throws -> Any {
          try PropertyListSerialization.propertyList(from: data, options: [], format: nil)
     }
@@ -22,6 +35,16 @@ public struct PlistFormat: SerializationFormat {
 }
 
 public struct JsonFormat: SerializationFormat {
+
+    public static var foldedRegexPattern: String {
+        let foldedMark = PathExplorerSerialization<Self>.foldedMark
+        let foldedKey = PathExplorerSerialization<Self>.foldedKey
+
+        return #"(?<=\[)\s*"\#(foldedMark)"\s*(?=\])"# // array
+        + #"|(?<=\{)\s*"\#(foldedKey)"\s*:\s*"\#(foldedMark)"\s*(?=\})"# // dict
+
+    }
+
     public static func serialize(data: Data) throws -> Any {
          try JSONSerialization.jsonObject(with: data, options: [])
     }

--- a/Sources/ScoutCLT/Add/AddCommand.swift
+++ b/Sources/ScoutCLT/Add/AddCommand.swift
@@ -31,6 +31,9 @@ struct AddCommand: ParsableCommand {
     @Flag(name: [.long], inversion: .prefixedNo, help: "Colorise the ouput")
     var color = true
 
+    @Option(name: [.short, .long], help: "Fold the data at the given depth level")
+    var level: Int?
+
     func run() throws {
 
         do {
@@ -50,17 +53,17 @@ struct AddCommand: ParsableCommand {
         if var json = try? Json(data: data) {
 
             try add(pathsAndValues, to: &json)
-            try ScoutCommand.output(output, dataWith: json, verbose: verbose, colorise: color)
+            try ScoutCommand.output(output, dataWith: json, verbose: verbose, colorise: color, level: level)
 
         } else if var plist = try? Plist(data: data) {
 
             try add(pathsAndValues, to: &plist)
-            try ScoutCommand.output(output, dataWith: plist, verbose: verbose, colorise: color)
+            try ScoutCommand.output(output, dataWith: plist, verbose: verbose, colorise: color, level: level)
 
         } else if var xml = try? Xml(data: data) {
 
             try add(pathsAndValues, to: &xml)
-            try ScoutCommand.output(output, dataWith: xml, verbose: verbose, colorise: color)
+            try ScoutCommand.output(output, dataWith: xml, verbose: verbose, colorise: color, level: level)
 
         } else {
             if let filePath = inputFilePath {

--- a/Sources/ScoutCLT/Delete/DeleteCommand.swift
+++ b/Sources/ScoutCLT/Delete/DeleteCommand.swift
@@ -36,6 +36,9 @@ struct DeleteCommand: ParsableCommand {
     @Flag(name: [.long], inversion: .prefixedNo, help: "Colorise the ouput")
     var color = true
 
+    @Option(name: [.short, .long], help: "Fold the data at the given depth level")
+    var level: Int?
+
     // MARK: - Functions
 
     func run() throws {
@@ -57,17 +60,17 @@ struct DeleteCommand: ParsableCommand {
         if var json = try? Json(data: data) {
 
             try readingPaths.forEach { try json.delete($0) }
-            try ScoutCommand.output(output, dataWith: json, verbose: verbose, colorise: color)
+            try ScoutCommand.output(output, dataWith: json, verbose: verbose, colorise: color, level: level)
 
         } else if var plist = try? Plist(data: data) {
 
             try readingPaths.forEach { try plist.delete($0) }
-            try ScoutCommand.output(output, dataWith: plist, verbose: verbose, colorise: color)
+            try ScoutCommand.output(output, dataWith: plist, verbose: verbose, colorise: color, level: level)
 
         } else if var xml = try? Xml(data: data) {
 
             try readingPaths.forEach { try xml.delete($0) }
-            try ScoutCommand.output(output, dataWith: xml, verbose: verbose, colorise: color)
+            try ScoutCommand.output(output, dataWith: xml, verbose: verbose, colorise: color, level: level)
 
         } else {
             if let filePath = inputFilePath {

--- a/Sources/ScoutCLT/Main/ScoutCommand.swift
+++ b/Sources/ScoutCLT/Main/ScoutCommand.swift
@@ -42,7 +42,7 @@ struct ScoutCommand: ParsableCommand {
 
     // MARK: - Functions
 
-    static func output<T: PathExplorer>(_ output: String?, dataWith pathExplorer: T, verbose: Bool, colorise: Bool) throws {
+    static func output<T: PathExplorer>(_ output: String?, dataWith pathExplorer: T, verbose: Bool, colorise: Bool, level: Int? = nil) throws {
         if let output = output?.replacingTilde {
             let fm = FileManager.default
             try fm.createFile(atPath: output, contents: pathExplorer.exportData(), attributes: nil)
@@ -73,6 +73,12 @@ struct ScoutCommand: ParsableCommand {
                 xmlInjector.delegate = XMLInjectorColorDelegate(colors: colors)
             }
             injector = xmlInjector
+        }
+
+        var pathExplorer = pathExplorer
+
+        if let level = level {
+            pathExplorer.fold(upTo: level)
         }
 
         var output = try pathExplorer.exportString()

--- a/Sources/ScoutCLT/Read/ReadCommand.swift
+++ b/Sources/ScoutCLT/Read/ReadCommand.swift
@@ -28,6 +28,9 @@ struct ReadCommand: ParsableCommand {
     @Flag(name: [.long], inversion: .prefixedNo, help: "Colorise the ouput")
     var color = true
 
+    @Option(name: [.short, .long], help: "Fold the data at the given depth level")
+    var level: Int?
+
     // MARK: - Functions
 
     func run() throws {
@@ -68,8 +71,11 @@ struct ReadCommand: ParsableCommand {
         var value: String
 
         if let json = try? Json(data: data) {
-            let key = try json.get(path)
-            value = key.stringValue != "" ? key.stringValue : key.description
+            var json = try json.get(path)
+            if let level = level {
+                json.fold(upTo: level)
+            }
+            value = json.stringValue != "" ? json.stringValue : json.description
 
             let jsonInjector = JSONInjector(type: .terminal)
             if let colors = try ScoutCommand.getColorFile()?.json {
@@ -78,8 +84,11 @@ struct ReadCommand: ParsableCommand {
             injector = jsonInjector
 
         } else if let plist = try? Plist(data: data) {
-            let key = try plist.get(path)
-            value = key.stringValue != "" ? key.stringValue : key.description
+            var plist = try plist.get(path)
+            if let level = level {
+                plist.fold(upTo: level)
+            }
+            value = plist.stringValue != "" ? plist.stringValue : plist.description
 
             let plistInjector = PlistInjector(type: .terminal)
             if let colors = try ScoutCommand.getColorFile()?.plist {
@@ -88,8 +97,11 @@ struct ReadCommand: ParsableCommand {
             injector = plistInjector
 
         } else if let xml = try? Xml(data: data) {
-            let key = try xml.get(path)
-            value = key.stringValue != "" ? key.stringValue : key.description
+            var xml = try xml.get(path)
+            if let level = level {
+                xml.fold(upTo: level)
+            }
+            value = xml.stringValue != "" ? xml.stringValue : xml.description
 
             let xmlInjector = XMLEnhancedInjector(type: .terminal)
             if let colors = try ScoutCommand.getColorFile()?.xml {

--- a/Sources/ScoutCLT/Set/SetCommand.swift
+++ b/Sources/ScoutCLT/Set/SetCommand.swift
@@ -31,6 +31,9 @@ struct SetCommand: ParsableCommand {
     @Flag(name: [.long], inversion: .prefixedNo, help: "Colorise the ouput")
     var color = true
 
+    @Option(name: [.short, .long], help: "Fold the data at the given depth level")
+    var level: Int?
+
     func run() throws {
 
         do {
@@ -50,17 +53,17 @@ struct SetCommand: ParsableCommand {
         if var json = try? Json(data: data) {
 
             try set(pathsAndValues, in: &json)
-            try ScoutCommand.output(output, dataWith: json, verbose: verbose, colorise: color)
+            try ScoutCommand.output(output, dataWith: json, verbose: verbose, colorise: color, level: level)
 
         } else if var plist = try? Plist(data: data) {
 
             try set(pathsAndValues, in: &plist)
-            try ScoutCommand.output(output, dataWith: plist, verbose: verbose, colorise: color)
+            try ScoutCommand.output(output, dataWith: plist, verbose: verbose, colorise: color, level: level)
 
         } else if var xml = try? Xml(data: data) {
 
             try set(pathsAndValues, in: &xml)
-            try ScoutCommand.output(output, dataWith: xml, verbose: verbose, colorise: color)
+            try ScoutCommand.output(output, dataWith: xml, verbose: verbose, colorise: color, level: level)
 
         } else {
             if let filePath = inputFilePath {

--- a/Tests/ScoutTests/Implementations/PathExplorerSerializationTests.swift
+++ b/Tests/ScoutTests/Implementations/PathExplorerSerializationTests.swift
@@ -429,4 +429,17 @@ final class PathExplorerSerializationTests: XCTestCase {
 
         XCTAssertErrorsEqual(try plist.add("Woomy", at: path), .wrongUsage(of: .count, in: path))
     }
+
+    // MARK: Folded
+
+    func testFolded() throws {
+        let data = try PropertyListEncoder().encode(characters)
+        var plist = try Plist(data: data)
+
+        plist.fold(upTo: 1)
+
+        let value = try plist.get(0, "episodes", 0).string
+
+        XCTAssertEqual(value, "~~SCOUT_FOLDED~~")
+    }
 }

--- a/Tests/ScoutTests/Implementations/PathExplorerXMLTests.swift
+++ b/Tests/ScoutTests/Implementations/PathExplorerXMLTests.swift
@@ -312,4 +312,16 @@ final class PathExplorerXMLTests: XCTestCase {
 
         XCTAssertErrorsEqual(try xml.add("Woomy", at: path), .wrongUsage(of: .count, in: path))
     }
+
+    // MARK: Folded
+
+    func testFolded() throws {
+        var xml = try Xml(data: toyBox)
+
+        xml.fold(upTo: 2)
+
+        let value = try xml.get("characters", 0, "episodes", 0).string
+
+        XCTAssertEqual(value, "~~SCOUT_FOLDED~~")
+    }
 }


### PR DESCRIPTION
Scout replaces the content of those objects by a single string key with a mark. Then replaces this mark with ”…” when exporting the string.

Closes #66 