### PR TITLE
[#105] Delete arrays or dictionaries when left empty

### DIFF
--- a/Sources/Scout/Definitions/PathExplorer+Extensions.swift
+++ b/Sources/Scout/Definitions/PathExplorer+Extensions.swift
@@ -62,6 +62,23 @@ extension PathExplorer {
     static var foldedMark: String { "~~SCOUT_FOLDED~~" }
 }
 
+// MARK: Helpers
+
+public extension PathExplorer {
+
+    /// Delete the key at the given path, specified as array.
+    /// - Throws: If the path is invalid (e.g. a key does not exist in a dictionary, or indicating an index on a non-array key)
+    mutating func delete(_ path: Path) throws {
+        try delete(path, deleteIfEmpty: false)
+    }
+
+    /// Delete the key at the given path, specified as array.
+    /// - Throws: If the path is invalid (e.g. a key does not exist in a dictionary, or indicating an index on a non-array key)
+    mutating func delete(_ path: PathElementRepresentable) throws {
+        try delete(path, deleteIfEmpty: false)
+    }
+}
+
 // MARK: Data validation
 
 extension PathExplorer {

--- a/Sources/Scout/Definitions/PathExplorer.swift
+++ b/Sources/Scout/Definitions/PathExplorer.swift
@@ -103,12 +103,14 @@ where
     // MARK: Delete
 
     /// Delete the key at the given path, specified as array.
+    /// - parameter deleteIfEmpty: When `true`, the dictionary or array holding the value will be deleted too if empty after the key deletion
     /// - Throws: If the path is invalid (e.g. a key does not exist in a dictionary, or indicating an index on a non-array key)
-    mutating func delete(_ path: Path) throws
+    mutating func delete(_ path: Path, deleteIfEmpty: Bool) throws
 
     /// Delete the key at the given path,specified as variadic `PathElementRepresentable`s
+    /// - parameter deleteIfEmpty: When `true`, the dictionary or array holding the value will be deleted too if empty after the key deletion
     /// - Throws: If the path is invalid (e.g. a key does not exist in a dictionary, or indicating an index on a non-array key)
-    mutating func delete(_ path: PathElementRepresentable...) throws
+    mutating func delete(_ path: PathElementRepresentable..., deleteIfEmpty: Bool) throws
 
     // MARK: Add
 

--- a/Sources/Scout/Implementations/Serialization/PathExplorerSerialization+Delete.swift
+++ b/Sources/Scout/Implementations/Serialization/PathExplorerSerialization+Delete.swift
@@ -80,7 +80,7 @@ extension PathExplorerSerialization {
         }
     }
 
-    public mutating func delete(_ path: Path) throws {
+    public mutating func delete(_ path: Path, deleteIfEmpty: Bool = false) throws {
         guard !path.isEmpty else { return }
 
         let (pathExplorers, path, lastElement) = try getExplorers(from: path)
@@ -93,7 +93,11 @@ extension PathExplorerSerialization {
 
         for (pathExplorer, element) in zip(pathExplorers, path).reversed() {
             var pathExplorer = pathExplorer
-            try pathExplorer.set(element: element, to: currentExplorer.value)
+            if deleteIfEmpty, currentExplorer.isEmpty {
+                try pathExplorer.delete(element: element)
+            } else {
+                try pathExplorer.set(element: element, to: currentExplorer.value)
+            }
             currentExplorer = pathExplorer
         }
 

--- a/Sources/Scout/Implementations/Serialization/PathExplorerSerialization.swift
+++ b/Sources/Scout/Implementations/Serialization/PathExplorerSerialization.swift
@@ -15,6 +15,17 @@ public struct PathExplorerSerialization<F: SerializationFormat>: PathExplorer {
     var isDictionary: Bool { value is DictionaryValue }
     var isArray: Bool { value is ArrayValue }
 
+    /// `true` if the value is an array or a dictionary and is empty
+    var isEmpty: Bool {
+        if let array = value as? ArrayValue {
+            return array.isEmpty
+        } else if let dict = value as? DictionaryValue {
+            return dict.isEmpty
+        } else {
+            return false
+        }
+    }
+
     /// `true` if the explorer has been folded
     var isFolded = false
 
@@ -123,8 +134,8 @@ public struct PathExplorerSerialization<F: SerializationFormat>: PathExplorer {
 
     // MARK: Delete
 
-    public mutating func delete(_ path: PathElementRepresentable...) throws {
-        try delete(Path(path))
+    public mutating func delete(_ path: PathElementRepresentable..., deleteIfEmpty: Bool = false) throws {
+        try delete(Path(path), deleteIfEmpty: deleteIfEmpty)
     }
 
     // MARK: Add

--- a/Sources/Scout/Implementations/XML/PathExplorerXML+Delete.swift
+++ b/Sources/Scout/Implementations/XML/PathExplorerXML+Delete.swift
@@ -5,9 +5,11 @@
 
 extension PathExplorerXML {
 
-    public mutating func delete(_ path: Path) throws {
+    public mutating func delete(_ path: Path, deleteIfEmpty: Bool = false) throws {
         var currentPath = Path()
 
+        // for each encountered slice, we'll add the sliced explorers in the array to then
+        // delete the common key in each of them
         var elementsToDelete = [self]
 
         try path.forEach { pathElement in
@@ -49,6 +51,10 @@ extension PathExplorerXML {
 
         elementsToDelete.forEach { pathExplorer in
             pathExplorer.element.removeFromParent()
+
+            if deleteIfEmpty, pathExplorer.element.parent?.children.isEmpty ?? false {
+                pathExplorer.element.parent?.removeFromParent()
+            }
         }
     }
 
@@ -76,9 +82,5 @@ extension PathExplorerXML {
         }
 
         child.removeFromParent()
-    }
-
-    public mutating func delete(_ path: PathElementRepresentable...) throws {
-        try delete(Path(path))
     }
 }

--- a/Sources/Scout/Implementations/XML/PathExplorerXML.swift
+++ b/Sources/Scout/Implementations/XML/PathExplorerXML.swift
@@ -112,6 +112,12 @@ public struct PathExplorerXML: PathExplorer {
         try set(Path(path), keyNameTo: newKeyName)
     }
 
+    // MARK: Delete
+
+    public mutating func delete(_ path: PathElementRepresentable..., deleteIfEmpty: Bool = false) throws {
+        try delete(Path(path), deleteIfEmpty: deleteIfEmpty)
+    }
+
     // MARK: Add
 
     public mutating func add<Type>(_ newValue: Any, at path: Path, as type: KeyType<Type>) throws where Type: KeyAllowedType {

--- a/Sources/ScoutCLT/Delete/DeleteCommand.swift
+++ b/Sources/ScoutCLT/Delete/DeleteCommand.swift
@@ -39,6 +39,9 @@ struct DeleteCommand: ParsableCommand {
     @Option(name: [.short, .long], help: "Fold the data at the given depth level")
     var level: Int?
 
+    @Flag(name: [.short, .long], help: "When the deleted value leaves the array or dictionary holding it empty, delete it too")
+    var recursive = false
+
     // MARK: - Functions
 
     func run() throws {
@@ -59,17 +62,17 @@ struct DeleteCommand: ParsableCommand {
 
         if var json = try? Json(data: data) {
 
-            try readingPaths.forEach { try json.delete($0) }
+            try readingPaths.forEach { try json.delete($0, deleteIfEmpty: recursive) }
             try ScoutCommand.output(output, dataWith: json, verbose: verbose, colorise: color, level: level)
 
         } else if var plist = try? Plist(data: data) {
 
-            try readingPaths.forEach { try plist.delete($0) }
+            try readingPaths.forEach { try plist.delete($0, deleteIfEmpty: recursive) }
             try ScoutCommand.output(output, dataWith: plist, verbose: verbose, colorise: color, level: level)
 
         } else if var xml = try? Xml(data: data) {
 
-            try readingPaths.forEach { try xml.delete($0) }
+            try readingPaths.forEach { try xml.delete($0, deleteIfEmpty: recursive) }
             try ScoutCommand.output(output, dataWith: xml, verbose: verbose, colorise: color, level: level)
 
         } else {

--- a/Tests/ScoutTests/Implementations/PathExplorerSerializationTests.swift
+++ b/Tests/ScoutTests/Implementations/PathExplorerSerializationTests.swift
@@ -22,7 +22,7 @@ final class PathExplorerSerializationTests: XCTestCase {
     struct Character: Encodable {
         let name: String
         let quote: String
-        let episodes = [1, 2, 3]
+        var episodes = [1, 2, 3]
     }
 
     struct StubStruct: Codable {
@@ -289,6 +289,19 @@ final class PathExplorerSerializationTests: XCTestCase {
         XCTAssertEqual(try plist.get(0, "episodes", PathElement.count).int, 2)
         XCTAssertEqual(try plist.get(1, "episodes", PathElement.count).int, 2)
         XCTAssertEqual(try plist.get(2, "episodes", PathElement.count).int, 3)
+    }
+
+    func testDeleteIfEmpty() throws {
+        var characters = self.characters
+        characters[0].episodes.removeLast(2)
+
+        let data = try PropertyListEncoder().encode(characters)
+        var plist = try Plist(data: data)
+        let path = Path(0, "episodes", 0)
+
+        try plist.delete(path, deleteIfEmpty: true)
+
+        XCTAssertErrorsEqual(try plist.get(0, "episodes"), .subscriptMissingKey(path: Path(0), key: "episodes", bestMatch: nil))
     }
 
     // MARK: Add


### PR DESCRIPTION
When deleting a value, it can be specified to also delete the dictionary or the array holding it if the value is the only one in it.

Closes #105 