### PR TITLE
[#119] Allow single element slicing

### DIFF
--- a/Sources/Scout/Definitions/PathElementRepresentable.swift
+++ b/Sources/Scout/Definitions/PathElementRepresentable.swift
@@ -29,11 +29,25 @@ extension String: PathElementRepresentable {
     var slice: PathElement? {
         let splitted = components(separatedBy: ":")
 
-        guard
-            splitted.count == 2,
-            let lower = splitted[0] == "" ? 0 : Int(splitted[0]),
-            let upper = splitted[1] == "" ? (lower < 0 ? .lastNegativeIndex : .lastIndex) : Int(splitted[1])
-        else {
+        guard splitted.count == 2 else {
+            return nil
+        }
+
+        var lowerBound: Bounds.Bound?
+        if splitted[0] == "" {
+            lowerBound = .first
+        } else if let lowerValue = Int(splitted[0]) {
+            lowerBound = .init(lowerValue)
+        }
+
+        var upperBound: Bounds.Bound?
+        if splitted[1] == "" {
+            upperBound = .last
+        } else if let upperValue = Int(splitted[1]) {
+            upperBound = .init(upperValue)
+        }
+
+        guard let lower = lowerBound, let upper = upperBound else {
             return nil
         }
 

--- a/Sources/Scout/Definitions/PathExplorerError.swift
+++ b/Sources/Scout/Definitions/PathExplorerError.swift
@@ -56,7 +56,7 @@ public enum PathExplorerError: LocalizedError, Equatable {
         case .subscriptWrongIndex(let path, let index, let count): return "The index [\(index)] is not within the bounds (0...\(count - 1)) of the Array  at '\(path.description)'"
         case .keyNameSetOnNonDictionary(path: let path): return "'\(path.description)' is not a dictionary and cannot set the key name of its children if any"
 
-        case .wrongBounds(let bounds, let path, let lastValidIndex): return "Wrong slice '[\(bounds.lowerString):\(bounds.upperString)] in '\(path.description)' Last index : \(lastValidIndex).\nValid slice: 0 <= lowerBound < upperBound <= lastIndex or -lastIndex - 1 <= lowerBound < upperBound <= 0."
+        case .wrongBounds(let bounds, let path, let lastValidIndex): return "Wrong slice '[\(bounds.lowerString):\(bounds.upperString)] in '\(path.description)' Last index : \(lastValidIndex).\nValid slice: 0 <= lowerBound <= upperBound <= lastIndex or -lastIndex <= lowerBound <= upperBound <= 0. Omit lower to target first index. Omit upper to target last index"
 
         case .wrongRegularExpression(let pattern, let path): return "Wrong regular expression pattern '\(pattern.description)' in '\(path.description)'."
 

--- a/Sources/Scout/Extensions/Int+LastIndex.swift
+++ b/Sources/Scout/Extensions/Int+LastIndex.swift
@@ -8,7 +8,4 @@ import Foundation
 extension Int {
     /// Represents the last index in an array
     static let lastIndex = -1
-
-    /// Represents the last possible negative index in an array when working with negative slices
-    static let lastNegativeIndex = 0
 }

--- a/Tests/ScoutTests/Definitions/PathTests.swift
+++ b/Tests/ScoutTests/Definitions/PathTests.swift
@@ -162,14 +162,14 @@ final class PathTests: XCTestCase {
     }
 
     func testPartialSliceLeft() throws {
-        let array = Path(secondKey, PathElement.slice(.init(lower: 0, upper: 4)))
+        let array = Path(secondKey, PathElement.slice(.init(lower: .first, upper: 4)))
         let path = try Path(string: secondKeyWithPartialRangeLeft)
 
         XCTAssertEqual(path, array)
     }
 
     func testPartialSliceRight() throws {
-        let array = Path(secondKey, PathElement.slice(.init(lower: 1, upper: .lastIndex)))
+        let array = Path(secondKey, PathElement.slice(.init(lower: 1, upper: .last)))
         let path = try Path(string: secondKeyWithPartialRangeRight)
 
         XCTAssertEqual(path, array)

--- a/Tests/ScoutTests/Implementations/Serialization/PathExplorerSerializationTests.swift
+++ b/Tests/ScoutTests/Implementations/Serialization/PathExplorerSerializationTests.swift
@@ -77,7 +77,7 @@ final class PathExplorerSerializationTests: XCTestCase {
         let data = try PropertyListEncoder().encode(characters)
         let plist = try Plist(data: data)
 
-        let csv = try plist.get(PathElement.slice(Bounds(lower: 0, upper: .lastIndex)), "episodes").exportCSVArrayOfArrays(separator: ";")
+        let csv = try plist.get(PathElement.slice(Bounds(lower: 0, upper: .last)), "episodes").exportCSVArrayOfArrays(separator: ";")
         let expectedValues = [["1", "2", "3"],
                               ["1", "2", "3"],
                               ["1", "2", "3"]]

--- a/Tests/ScoutTests/Implementations/XML/PathExplorerXMLTests.swift
+++ b/Tests/ScoutTests/Implementations/XML/PathExplorerXMLTests.swift
@@ -173,7 +173,7 @@ final class PathExplorerXMLTests: XCTestCase {
     func testExportCSVArray() throws {
         let xml = try Xml(data: toyBox)
 
-        let (headers, values) = try xml.get("characters", PathElement.slice(Bounds(lower: 0, upper: .lastIndex)), "episodes").exportCSVHeadersAndValues(separator: ";")
+        let (headers, values) = try xml.get("characters", PathElement.slice(Bounds(lower: 0, upper: .last)), "episodes").exportCSVHeadersAndValues(separator: ";")
 
         let expectedValues = [["1", "2", "3"],
                               ["1", "2", "3"],

--- a/Tests/ScoutTests/Models/BoundsTests.swift
+++ b/Tests/ScoutTests/Models/BoundsTests.swift
@@ -8,45 +8,96 @@ import Scout
 
 final class BoundsTests: XCTestCase {
 
+    let stubPath = Path("flower", "power")
+
+    func testGetArraySlice() throws {
+        let bounds = Bounds(lower: 2, upper: 7)
+        let path = stubPath.appending(.slice(bounds))
+
+        XCTAssertEqual(try bounds.range(lastValidIndex: 10, path: path), 2...7)
+    }
+
+    func testGetArraySlice_FirstIndex() throws {
+        let bounds = Bounds(lower: .first, upper: 5)
+        let path = stubPath.appending(.slice(bounds))
+
+        XCTAssertEqual(try bounds.range(lastValidIndex: 10, path: path), 0...5)
+    }
+
     func testGetArraySlice_LastIndex() throws {
-        let bounds = Bounds(lower: 2, upper: -1)
-        let path = Path("flower", "power", PathElement.slice(bounds))
+        let bounds = Bounds(lower: 2, upper: .last)
+        let path = stubPath.appending(.slice(bounds))
 
         XCTAssertEqual(try bounds.range(lastValidIndex: 5, path: path), 2...5)
     }
 
-    func testGetArraySlice_LowerLesserThan0() throws {
-        let bounds = Bounds(lower: -2, upper: 0)
-        let path = Path("flower", "power", PathElement.slice(bounds))
+    func testGetArraySlice_LowerNegative() throws {
+        let bounds = Bounds(lower: -2, upper: .last)
+        let path = stubPath.appending(.slice(bounds))
 
-        XCTAssertEqual(try bounds.range(lastValidIndex: 5, path: path), 4...5)
+        XCTAssertEqual(try bounds.range(lastValidIndex: 5, path: path), 3...5)
     }
 
-    func testRange_ThrowsIfLowerLesserThan0() throws {
-        let bounds = Bounds(lower: -2, upper: 1)
-        let path = Path("flower", "power", PathElement.slice(bounds))
+    func testGetArraySlice_UpperNegative() throws {
+        let bounds = Bounds(lower: 4, upper: -2)
+        let path = stubPath.appending(.slice(bounds))
+
+        XCTAssertEqual(try bounds.range(lastValidIndex: 10, path: path), 4...8)
+    }
+
+    func testGetArraySlice_LowerNegativeAndUpperEquals0Throws() throws {
+        let bounds = Bounds(lower: -2, upper: 0)
+        let path = stubPath.appending(.slice(bounds))
 
         XCTAssertErrorsEqual(try bounds.range(lastValidIndex: 10, path: path), .wrongBounds(bounds, in: path, lastValidIndex: 10))
     }
 
-    func testGetArraySlice_ThrowsIfLowerGreaterThanLastIndex() throws {
+    func testGetArraySlice_LowerGreaterThanLastIndexThrows() throws {
         let bounds = Bounds(lower: 10, upper: 1)
-        let path = Path("flower", "power", PathElement.slice(bounds))
+        let path = stubPath.appending(.slice(bounds))
 
         XCTAssertErrorsEqual(try bounds.range(lastValidIndex: 5, path: path), .wrongBounds(bounds, in: path, lastValidIndex: 5))
     }
 
-    func testGetArraySlice_ThrowsIfUpperLesserThanLower() throws {
+    func testRange_LowerNegativeGreaterThanUpperThrows() throws {
+        let bounds = Bounds(lower: -2, upper: 1)
+        let path = stubPath.appending(.slice(bounds))
+
+        XCTAssertErrorsEqual(try bounds.range(lastValidIndex: 10, path: path), .wrongBounds(bounds, in: path, lastValidIndex: 10))
+    }
+
+    func testGetArraySlice_UpperLesserThanLowerThrows() throws {
         let bounds = Bounds(lower: 2, upper: 1)
-        let path = Path("flower", "power", PathElement.slice(bounds))
+        let path = stubPath.appending(.slice(bounds))
 
         XCTAssertErrorsEqual(try bounds.range(lastValidIndex: 5, path: path), .wrongBounds(bounds, in: path, lastValidIndex: 5))
     }
 
-    func testGetArraySlice_ThrowsIfUpperEqualsLower() throws {
-        let bounds = Bounds(lower: 2, upper: 2)
-        let path = Path("flower", "power", PathElement.slice(bounds))
+    func testRange_UpperNegativeLesserThanLowerThrows() throws {
+        let bounds = Bounds(lower: 5, upper: -7)
+        let path = stubPath.appending(.slice(bounds))
 
-        XCTAssertErrorsEqual(try bounds.range(lastValidIndex: 5, path: path), .wrongBounds(bounds, in: path, lastValidIndex: 5))
+        XCTAssertErrorsEqual(try bounds.range(lastValidIndex: 10, path: path), .wrongBounds(bounds, in: path, lastValidIndex: 10))
+    }
+
+    func testEqualBound() {
+        let bound5 = Bounds.Bound(5)
+        let bound5Bis = Bounds.Bound(5)
+
+        XCTAssertEqual(bound5, bound5Bis)
+    }
+
+    func testNotEqualsBound() {
+        let bound5 = Bounds.Bound(5)
+        let bound10 = Bounds.Bound(10)
+
+        XCTAssertNotEqual(bound5, bound10)
+    }
+
+    func testNotEqualsBoundWithIdentifier() {
+        let bound5 = Bounds.Bound(5)
+        let bound5WithIdentifier = Bounds.Bound.last
+
+        XCTAssertNotEqual(bound5, bound5WithIdentifier)
     }
 }


### PR DESCRIPTION
The lower and upper int properties of the Bounds struct have been replaced by a Bound struct to differentiate first/last and 0

Closes #119 