### PR TITLE
[#121] Keys list

### DIFF
--- a/Sources/Scout/Definitions/PathElement.swift
+++ b/Sources/Scout/Definitions/PathElement.swift
@@ -17,6 +17,9 @@ public enum PathElement: Equatable {
     /// Placed after an array or dictionary to return its count
     case count
 
+    /// Placed after a dictionary to returns its keys as an array
+    case keysList
+
     /// Placed after an array to slice it with a `Bounds` value
     case slice(Bounds)
 
@@ -25,6 +28,7 @@ public enum PathElement: Equatable {
 
     // -- Symbols
     static let defaultCountSymbol = "#"
+    static let defaultKeysListSymbol = "#"
 
     // MARK: - Properties
 
@@ -50,7 +54,7 @@ public enum PathElement: Equatable {
     public var isGroupSubscripter: Bool {
         switch self {
         case .count, .index, .slice, .filter: return true
-        case .key: return false
+        case .key, .keysList: return false
         }
     }
 
@@ -59,6 +63,7 @@ public enum PathElement: Equatable {
         case .key: return "A key subscript a dictionary and is specified with a dot '.' then the key name like 'dictionary.keyName'"
         case .index: return "An index subscript an array and is specified as an integer enclosed with square brackets like '[1]'"
         case .count: return "A count element is specified as a sharp sign enclosed with square brackets '[#]'. It should be the last path element after an array or a dictionary."
+        case .keysList: return "A keys list element is specified as a sharp sign enclosed by curl brackets '{#}'. It is placed after a dictionary to get its keys as an array"
         case .slice: return "A slice is specified after an array with lower and upper bounds. It is enclosed by square brackets and the bounds are specified separated by ':' like '[lower:upper]'"
         case .filter: return "A filter is a regular expression placed after a dictionary to filter the keys to target. It is enclosed by sharp signs like '#[a-zA-Z]*#'"
         }
@@ -104,6 +109,7 @@ extension PathElement: CustomStringConvertible {
         case .key(let key): return key
         case .index(let index): return "[\(index)]"
         case .count: return "[\(Self.defaultCountSymbol)]"
+        case .keysList: return "{\(Self.defaultKeysListSymbol)}"
         case .slice(let bounds):
             let lowerBound = bounds.lowerString
             let upperBound = bounds.upperString

--- a/Sources/Scout/Definitions/PathExplorerError.swift
+++ b/Sources/Scout/Definitions/PathExplorerError.swift
@@ -56,7 +56,12 @@ public enum PathExplorerError: LocalizedError, Equatable {
         case .subscriptWrongIndex(let path, let index, let count): return "The index [\(index)] is not within the bounds (0...\(count - 1)) of the Array  at '\(path.description)'"
         case .keyNameSetOnNonDictionary(path: let path): return "'\(path.description)' is not a dictionary and cannot set the key name of its children if any"
 
-        case .wrongBounds(let bounds, let path, let lastValidIndex): return "Wrong slice '[\(bounds.lowerString):\(bounds.upperString)] in '\(path.description)' Last index : \(lastValidIndex).\nValid slice: 0 <= lowerBound <= upperBound <= lastIndex or -lastIndex <= lowerBound <= upperBound <= 0. Omit lower to target first index. Omit upper to target last index"
+        case .wrongBounds(let bounds, let path, let lastValidIndex): return
+            """
+            Wrong slice '[\(bounds.lowerString):\(bounds.upperString)]' in '\(path.description)' Last index : \(lastValidIndex).
+            Valid slice: 0 <= lowerBound <= upperBound <= lastIndex. Negative bounds are substracted to the last index (-bound -> lastIndex - bound).
+            Omit lower to target first index. Omit upper to target last index
+            """
 
         case .wrongRegularExpression(let pattern, let path): return "Wrong regular expression pattern '\(pattern.description)' in '\(path.description)'."
 

--- a/Sources/Scout/Extensions/AEXMLElement + Extension.swift
+++ b/Sources/Scout/Extensions/AEXMLElement + Extension.swift
@@ -7,6 +7,9 @@ import AEXML
 
 extension AEXMLElement {
 
+    /// Copy of the element, without the children
+    func copy() -> AEXMLElement { AEXMLElement(name: name, value: value, attributes: attributes) }
+
     /// xml keys have to have a key name. If the key has existing children,
     /// we will take the name of the first child. Otherwise we will remove the "s" from the parent key name
     var childrenName: String {

--- a/Sources/Scout/Implementations/Serialization/PathExplorerSerialization+Add.swift
+++ b/Sources/Scout/Implementations/Serialization/PathExplorerSerialization+Add.swift
@@ -45,7 +45,7 @@ extension PathExplorerSerialization {
         switch childKey {
         case .key: return DictionaryValue()
         case .index: return ArrayValue()
-        case .count, .slice, .filter: throw PathExplorerError.wrongUsage(of: childKey, in: readingPath)
+        case .count, .keysList, .slice, .filter: throw PathExplorerError.wrongUsage(of: childKey, in: readingPath)
         }
     }
 

--- a/Sources/Scout/Implementations/Serialization/PathExplorerSerialization+Delete.swift
+++ b/Sources/Scout/Implementations/Serialization/PathExplorerSerialization+Delete.swift
@@ -207,7 +207,7 @@ extension PathExplorerSerialization {
 
         case .key(let key): try delete(for: key)
         case .index(let index): try delete(at: index)
-        case .count: throw PathExplorerError.wrongUsage(of: element, in: readingPath.appending(element))
+        case .count, .keysList: throw PathExplorerError.wrongUsage(of: element, in: readingPath.appending(element))
         case .slice(let bounds): try deleteArraySlice(within: bounds)
         case .filter(let pattern): try deleteDictionaryFilter(with: pattern)
         }

--- a/Sources/Scout/Implementations/Serialization/PathExplorerSerialization+Get.swift
+++ b/Sources/Scout/Implementations/Serialization/PathExplorerSerialization+Get.swift
@@ -191,6 +191,15 @@ extension PathExplorerSerialization {
         return PathExplorerSerialization(value: countsDict, path: readingPath.appending(.count))
     }
 
+    // MARK: - Keys list
+
+    func getKeysList() throws -> Self {
+        let dict = try cast(value, as: .dictionary, orThrow: .dictionarySubscript(readingPath))
+        let keys = Array(dict.keys).sorted()
+
+        return PathExplorerSerialization(value: keys, path: readingPath.appending(.keysList))
+    }
+
     // MARK: - Group
 
     func getSingle(_ groupSample: GroupSample) throws -> Self {
@@ -304,6 +313,7 @@ extension PathExplorerSerialization {
         case .key(let key): return try get(for: key, detailedName: detailedName)
         case .index(let index): return try get(at: index, negativeIndexEnabled: negativeIndexEnabled)
         case .count: return try getChildrenCount()
+        case .keysList: return try getKeysList()
         case .slice(let bounds): return try getArraySlice(within: bounds, detailedName: detailedName)
         case .filter(let pattern): return try getDictionaryFilter(with: pattern)
         }

--- a/Sources/Scout/Implementations/Serialization/PathExplorerSerialization+Set.swift
+++ b/Sources/Scout/Implementations/Serialization/PathExplorerSerialization+Set.swift
@@ -236,7 +236,7 @@ extension PathExplorerSerialization {
         switch element {
         case .key(let key): return try set(for: key, to: newValue)
         case .index(let index): return try set(at: index, to: newValue)
-        case .count: throw PathExplorerError.wrongUsage(of: element, in: readingPath.appending(element))
+        case .count, .keysList: throw PathExplorerError.wrongUsage(of: element, in: readingPath.appending(element))
         case .slice(let bounds): try setArraySlice(within: bounds, to: newValue)
         case .filter(let pattern): try setDictionaryFilter(with: pattern, to: newValue)
         }

--- a/Sources/Scout/Implementations/XML/PathExplorerXML+Add.swift
+++ b/Sources/Scout/Implementations/XML/PathExplorerXML+Add.swift
@@ -47,13 +47,13 @@ extension PathExplorerXML {
 
         case .key(let key): try add(newValue: newValue, for: key)
         case .index(let index): try add(newValue: newValue, at: index)
-        case .count, .slice, .filter: throw PathExplorerError.wrongUsage(of: pathElement, in: readingPath)
+        case .count, .keysList, .slice, .filter: throw PathExplorerError.wrongUsage(of: pathElement, in: readingPath)
         }
     }
 
     mutating func insertChild(named keyName: String, withValue value: String, at index: Int) {
         // we have to copy the element as we cannot modify its children
-        let copy = AEXMLElement(name: element.name, value: element.value, attributes: element.attributes)
+        let copy = element.copy()
 
         // parse the children and just adding them until we reach index to insert the new child
         for childIndex in 0...element.children.count {

--- a/Sources/Scout/Implementations/XML/PathExplorerXML+Delete.swift
+++ b/Sources/Scout/Implementations/XML/PathExplorerXML+Delete.swift
@@ -31,8 +31,8 @@ extension PathExplorerXML {
             case .filter(let pattern):
                 try delete(.dictionaryFilter(pattern), in: &explorers, path: currentPath)
 
-            case .count:
-                throw PathExplorerError.wrongUsage(of: .count, in: currentPath)
+            case .count, .keysList:
+                throw PathExplorerError.wrongUsage(of: pathElement, in: currentPath)
             }
         }
 

--- a/Sources/Scout/Implementations/XML/PathExplorerXML+Get.swift
+++ b/Sources/Scout/Implementations/XML/PathExplorerXML+Get.swift
@@ -140,6 +140,22 @@ extension PathExplorerXML {
                                path: readingPath.appending(.count))
     }
 
+    func getKeysList() throws -> Self {
+        var keyChildren = [AEXMLElement]()
+
+        // get the keys names
+        element.children.forEach { child in
+            let keyChild = AEXMLElement(name: "key", value: child.name)
+            keyChildren.append(keyChild)
+        }
+
+        // new element
+        let copy = element.copy()
+        copy.name = copy.name + PathElement.keysList.description
+        copy.addChildren(keyChildren.sorted { $0.string < $1.string })
+        return PathExplorerXML(element: copy, path: readingPath.appending(.keysList))
+    }
+
     // MARK: - Group
 
     /// Returns a slice of value is it is an array
@@ -216,6 +232,7 @@ extension PathExplorerXML {
         case .key(let key): return try get(for: key)
         case .index(let index): return try get(at: index, negativeIndexEnabled: negativeIndexEnabled)
         case .count: return try getChildrenCount()
+        case .keysList: return try getKeysList()
         case .slice(let bounds): return try getArraySlice(within: bounds)
         case .filter(let pattern): return try getDictionaryFilter(with: pattern)
         }

--- a/Sources/Scout/Implementations/XML/PathExplorerXML.swift
+++ b/Sources/Scout/Implementations/XML/PathExplorerXML.swift
@@ -26,7 +26,7 @@ public struct PathExplorerXML: PathExplorer {
     public var description: String {
         // when priting out an element which has a parent, the identation will remain the same
         // which is unwanted so remove the parent by copying the element (parent setter is internal)
-        let copy = AEXMLElement(name: element.name, value: element.value, attributes: element.attributes)
+        let copy = element.copy()
         copy.addChildren(element.children)
         var description = copy.xml
 

--- a/Tests/ScoutTests/Definitions/PathTests.swift
+++ b/Tests/ScoutTests/Definitions/PathTests.swift
@@ -22,6 +22,7 @@ final class PathTests: XCTestCase {
     let secondKeyWithTwoNestedArrays = "secondKey[1][0][2]"
     let secondKeyWithFourthSeparatorAndIndex = "second$key[1]"
     let secondKeyWithCount = "secondKey[#]"
+    let secondKeyWithKeysList = "secondKey{#}"
     let secondKeyWithFullRange = "secondKey[2:4]"
     let secondKeyWithPartialRangeLeft = "secondKey[:4]"
     let secondKeyWithPartialRangeRight = "secondKey[1:]"
@@ -148,6 +149,22 @@ final class PathTests: XCTestCase {
     func testCountNotFinal() throws {
         let array: Path = [thirdKey, PathElement.count, secondKey]
         let path = try Path(string: thirdKeyWithCount)
+
+        XCTAssertEqual(path, array)
+    }
+
+    // MARK: - Keys list
+
+    func testKeysList() throws {
+        let array: Path = [secondKey, PathElement.keysList]
+        let path = try Path(string: secondKeyWithKeysList)
+
+        XCTAssertEqual(path, array)
+    }
+
+    func testKeysListFirstElement() throws {
+        let array: Path = [PathElement.keysList, 1]
+        let path = try Path(string: "{#}[1]")
 
         XCTAssertEqual(path, array)
     }

--- a/Tests/ScoutTests/Implementations/Serialization/PathExplorerSerializationTests+Get.swift
+++ b/Tests/ScoutTests/Implementations/Serialization/PathExplorerSerializationTests+Get.swift
@@ -296,4 +296,21 @@ extension PathExplorerSerializationTests {
         XCTAssertErrorsEqual(try plist.add("Woomy", at: path), .wrongUsage(of: .count, in: path))
     }
 
+    // MARK: - Keys list
+
+    func testGetKeysListDict() throws {
+        let data = try PropertyListEncoder().encode(charactersByName)
+        let plist = try Plist(data: data)
+        let path: Path = [PathElement.keysList]
+
+        XCTAssertEqual(try plist.get(path).value as? [String], ["Buzz", "Woody", "Zurg"])
+    }
+
+    func testGetKeysListSubDict() throws {
+        let data = try PropertyListEncoder().encode(charactersByName)
+        let plist = try Plist(data: data)
+        let path: Path = ["Woody", PathElement.keysList]
+
+        XCTAssertEqual(try plist.get(path).value as? [String], ["episodes", "name", "quote"])
+    }
 }

--- a/Tests/ScoutTests/Implementations/XML/PathExplorerXMLTests+Get.swift
+++ b/Tests/ScoutTests/Implementations/XML/PathExplorerXMLTests+Get.swift
@@ -184,4 +184,35 @@ extension PathExplorerXMLTests {
 
         XCTAssertErrorsEqual(try xml.add("Woomy", at: path), .wrongUsage(of: .count, in: path))
     }
+
+    // MARK: - Keys list
+
+    func testGetKeysListDict() throws {
+        let xml = try Xml(data: toyBoxByName)
+        let path = Path("toybox", "characters", PathElement.keysList)
+
+        let element = try xml.get(path).element
+
+        let names = ["Buzz", "Woody", "Zurg"]
+
+        XCTAssertEqual(element.name, "characters{#}")
+        for i in 0...2 {
+            XCTAssertEqual(element.children[i].name, "key")
+            XCTAssertEqual(element.children[i].string, names[i])
+        }
+    }
+
+    func testGetKeysListSubDict() throws {
+        let xml = try Xml(data: toyBoxByName)
+        let path = Path("toybox", "characters", "Woody", PathElement.keysList)
+
+        let element = try xml.get(path).element
+
+        let names = ["episodes", "name", "quote"]
+
+        for i in 0...2 {
+            XCTAssertEqual(element.children[i].name, "key")
+            XCTAssertEqual(element.children[i].string, names[i])
+        }
+    }
 }


### PR DESCRIPTION
New PathElement.keysList placed after a dictionary to get the keys as an array.
Powerful when used with the `csv-sep` option in bash/zsh to iterate over the keys.