### PR TITLE
Refactoring

### DIFF
--- a/Sources/Scout/Definitions/GroupSample.swift
+++ b/Sources/Scout/Definitions/GroupSample.swift
@@ -32,4 +32,6 @@ enum GroupSample: CustomStringConvertible {
         case .dictionaryFilter(let pattern): return .filter(pattern)
         }
     }
+
+    static func indexDescription(_ index: Int) -> String { "index(\(index))" }
 }

--- a/Sources/Scout/Definitions/GroupSample.swift
+++ b/Sources/Scout/Definitions/GroupSample.swift
@@ -10,11 +10,19 @@ enum GroupSample: CustomStringConvertible {
 
     static var arraySliceEmpty: Self { .arraySlice(Bounds(lower: 0, upper: 0)) }
     static var dictionaryFilterEmpty: Self { .dictionaryFilter("") }
+    static let keySeparator = "_"
 
-    var description: String {
+    var name: String {
         switch self {
         case .arraySlice: return "an Array"
         case .dictionaryFilter: return "a Dictionary"
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .arraySlice(let bounds): return "slice(\(bounds.lowerString),\(bounds.upperString))"
+        case .dictionaryFilter(let pattern): return "filter(\(pattern))"
         }
     }
 

--- a/Sources/Scout/Definitions/Path.swift
+++ b/Sources/Scout/Definitions/Path.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-/// Array of `PathElementRepresentable` to find a specific value in a `PathExplorer`
+/// Collection of `PathElement`s to subscript a `PathExplorer`
 public struct Path: Equatable {
 
     // MARK: - Constants

--- a/Sources/Scout/Extensions/AEXMLElement + Extension.swift
+++ b/Sources/Scout/Extensions/AEXMLElement + Extension.swift
@@ -30,13 +30,13 @@ extension AEXMLElement {
     var commonChildrenName: String? {
         guard
             let firstChild = children.first,
-            let name = firstChild.name.components(separatedBy: Path.defaultSeparator).last
+            let name = firstChild.name.components(separatedBy: GroupSample.keySeparator).last
         else {
             return nil
         }
 
         for child in children {
-            if child.name.components(separatedBy: ".").last != name {
+            if child.name.components(separatedBy: GroupSample.keySeparator).last != name {
                 return nil
             }
         }

--- a/Sources/Scout/Implementations/Serialization/PathExplorerSerialization+CSV.swift
+++ b/Sources/Scout/Implementations/Serialization/PathExplorerSerialization+CSV.swift
@@ -153,7 +153,7 @@ extension PathExplorerSerialization {
             }
         } else if let array = value as? ArrayValue {
             for (index, value) in array.enumerated() {
-                let newKey = key == "" ? key : key + GroupSample.keySeparator + "index(\(index))"
+                let newKey = key == "" ? key : key + GroupSample.keySeparator + GroupSample.indexDescription(index)
 
                 if key != "" && !isGroup(value: value) {
                     block(newKey, value)

--- a/Sources/Scout/Implementations/Serialization/PathExplorerSerialization+CSV.swift
+++ b/Sources/Scout/Implementations/Serialization/PathExplorerSerialization+CSV.swift
@@ -144,7 +144,7 @@ extension PathExplorerSerialization {
             dict.forEach { (keyValue, value) in
                 var newKey = keyValue
                 if key != "" {
-                    newKey = key + Path.defaultSeparator + keyValue
+                    newKey = key + GroupSample.keySeparator + keyValue
                 }
                 if !isGroup(value: value) {
                     block(newKey, value)
@@ -153,7 +153,7 @@ extension PathExplorerSerialization {
             }
         } else if let array = value as? ArrayValue {
             for (index, value) in array.enumerated() {
-                let newKey = key == "" ? key : key + PathElement.index(index).description
+                let newKey = key == "" ? key : key + GroupSample.keySeparator + "index(\(index))"
 
                 if key != "" && !isGroup(value: value) {
                     block(newKey, value)

--- a/Sources/Scout/Implementations/Serialization/PathExplorerSerialization+Get.swift
+++ b/Sources/Scout/Implementations/Serialization/PathExplorerSerialization+Get.swift
@@ -71,7 +71,7 @@ extension PathExplorerSerialization {
         try dictionary.forEach { (key, value) in
             let pathExplorer = PathExplorerSerialization(value: value, path: readingPath.appending(key))
             let newValue = try pathExplorer.getSingle(at: index)
-            let newName = detailedName ? key + GroupSample.keySeparator + "index(\(index))" : key
+            let newName = detailedName ? key + GroupSample.keySeparator + GroupSample.indexDescription(index) : key
             newDictFilter[newName] = newValue
         }
 

--- a/Sources/Scout/Implementations/Serialization/PathExplorerSerialization+Get.swift
+++ b/Sources/Scout/Implementations/Serialization/PathExplorerSerialization+Get.swift
@@ -71,7 +71,7 @@ extension PathExplorerSerialization {
         try dictionary.forEach { (key, value) in
             let pathExplorer = PathExplorerSerialization(value: value, path: readingPath.appending(key))
             let newValue = try pathExplorer.getSingle(at: index)
-            let newName = detailedName ? key + PathElement.index(index).description : key
+            let newName = detailedName ? key + GroupSample.keySeparator + "index(\(index))" : key
             newDictFilter[newName] = newValue
         }
 
@@ -134,7 +134,7 @@ extension PathExplorerSerialization {
         try dictionary.forEach { (keyValue, value) in
             let pathExplorer = PathExplorerSerialization(value: value, path: readingPath.appending(keyValue))
             let value = try pathExplorer.getDictAndValueFor(for: key).value
-            let newName = detailedName ? keyValue + Path.defaultSeparator + key : keyValue
+            let newName = detailedName ? keyValue + GroupSample.keySeparator + key : keyValue
             newDictFilter[newName] = value
         }
 
@@ -293,7 +293,7 @@ extension PathExplorerSerialization {
             let path = readingPath.appending(key)
             let pathExplorer = PathExplorerSerialization(value: value, path: path)
             let filteredDict = try pathExplorer.getSingle(groupSample).value
-            let newName = detailedName ? key + groupSample.pathElement.description : key
+            let newName = detailedName ? key + GroupSample.keySeparator + groupSample.description : key
             newDict[newName] = filteredDict
         }
 

--- a/Sources/Scout/Implementations/Serialization/PathExplorerSerialization+Set.swift
+++ b/Sources/Scout/Implementations/Serialization/PathExplorerSerialization+Set.swift
@@ -56,7 +56,7 @@ extension PathExplorerSerialization {
     /// Set the given index in the array slice by browsing all the arrays in the slice
     func set(at index: Int, inArraySlice array: inout ArrayValue, to newValues: ArrayValue) throws {
         guard array.count == newValues.count else {
-            throw PathExplorerError.wrongGroupValueForKey(group: GroupSample.arraySliceEmpty.description,
+            throw PathExplorerError.wrongGroupValueForKey(group: GroupSample.arraySliceEmpty.name,
                                                           value: String(describing: newValues),
                                                           element: .index(index))
         }
@@ -120,7 +120,7 @@ extension PathExplorerSerialization {
     /// Set the given key in the array slice by browsing all the arrays in the slice
     func set(for key: String, inArraySlice array: inout ArrayValue, to newValues: ArrayValue) throws {
         guard array.count == newValues.count else {
-            throw PathExplorerError.wrongGroupValueForKey(group: GroupSample.arraySliceEmpty.description,
+            throw PathExplorerError.wrongGroupValueForKey(group: GroupSample.arraySliceEmpty.name,
                                                           value: String(describing: newValues),
                                                           element: .key(key))
         }
@@ -152,7 +152,7 @@ extension PathExplorerSerialization {
         let slice = PathElement.slice(bounds)
         let array = try cast(value, as: .array, orThrow: .arraySubscript(readingPath))
         let newSlice = try cast(newValue, as: .array,
-                                orThrow: .wrongGroupValueForKey(group: GroupSample.arraySliceEmpty.description, value: String(describing: newValue), element: slice))
+                                orThrow: .wrongGroupValueForKey(group: GroupSample.arraySliceEmpty.name, value: String(describing: newValue), element: slice))
 
         let range = try bounds.range(lastValidIndex: array.count - 1, path: readingPath)
         let leftRange = range.lowerBound > 0 ? 0...range.lowerBound - 1 : nil
@@ -184,7 +184,7 @@ extension PathExplorerSerialization {
         var newDictFilter = try cast(value, as: .dictionary, orThrow: .dictionarySubscript(readingPath))
 
         let newDict = try cast(newValue, as: .dictionary,
-                                orThrow: .wrongGroupValueForKey(group: GroupSample.arraySliceEmpty.description, value: String(describing: newValue), element: filter))
+                                orThrow: .wrongGroupValueForKey(group: GroupSample.arraySliceEmpty.name, value: String(describing: newValue), element: filter))
 
         newDict.forEach { (key, value) in
             if !allowEmptyGroups, PathExplorerSerialization(value: value).isEmpty {

--- a/Sources/Scout/Implementations/XML/PathExplorerXML+CSV.swift
+++ b/Sources/Scout/Implementations/XML/PathExplorerXML+CSV.swift
@@ -84,10 +84,10 @@ extension PathExplorerXML {
         let childrenName = element.commonChildrenName
         for (index, child) in element.children.enumerated() {
             let newKey: String
-            if child.name.components(separatedBy: Path.defaultSeparator).last == childrenName { // array
+            if child.name.components(separatedBy: GroupSample.keySeparator).last == childrenName { // array
                 newKey = key == "" ? key : key + PathElement.index(index).description
             } else { // dictionary
-                newKey = key == "" ? child.name : key + Path.defaultSeparator + child.name
+                newKey = key == "" ? child.name : key + GroupSample.keySeparator + child.name
             }
 
             exploreGroup(key: newKey, element: child, toExecute: block)

--- a/Sources/Scout/Implementations/XML/PathExplorerXML+Get.swift
+++ b/Sources/Scout/Implementations/XML/PathExplorerXML+Get.swift
@@ -57,7 +57,7 @@ extension PathExplorerXML {
         try element.children.forEach { child in
             let pathExplorer = PathExplorerXML(element: child, path: readingPath.appending(child.name))
             let newChild = try pathExplorer.getSingle(at: index)
-            newChild.name = child.name + PathElement.index(index).description
+            newChild.name = child.name + GroupSample.keySeparator + "index(\(index))"
             copy.addChild(newChild)
         }
 
@@ -96,7 +96,7 @@ extension PathExplorerXML {
     }
 
     func getInArraySlice(for key: String) throws -> AEXMLElement {
-        let copy = AEXMLElement(name: element.name + Path.defaultSeparator + PathElement.key(key).description)
+        let copy = AEXMLElement(name: element.name + GroupSample.keySeparator + key)
 
         for (index, child) in element.children.enumerated() {
             let pathExplorer = PathExplorerXML(element: child, path: readingPath.appending(index))
@@ -107,12 +107,12 @@ extension PathExplorerXML {
     }
 
     func getInDictionaryFilter(for key: String) throws -> AEXMLElement {
-        let copy = AEXMLElement(name: element.name + Path.defaultSeparator + PathElement.key(key).description)
+        let copy = AEXMLElement(name: element.name + GroupSample.keySeparator + key)
 
         try element.children.forEach { child in
             let pathExplorer = PathExplorerXML(element: child, path: readingPath.appending(child.name))
             let newChild = try pathExplorer.getSingle(for: key)
-            newChild.name = child.name + Path.defaultSeparator + newChild.name
+            newChild.name = child.name + GroupSample.keySeparator + newChild.name
             copy.addChild(newChild)
         }
         return copy
@@ -162,7 +162,8 @@ extension PathExplorerXML {
     func getArraySlice(within bounds: Bounds) throws -> PathExplorerXML {
         let slice = PathElement.slice(bounds)
         // we have to copy the element as we cannot modify its children
-        let copy = AEXMLElement(name: element.name + slice.description, value: element.value, attributes: element.attributes)
+        let newKeyName = element.name + GroupSample.keySeparator + GroupSample.arraySlice(bounds).description
+        let copy = AEXMLElement(name: newKeyName, value: element.value, attributes: element.attributes)
         let path = readingPath.appending(slice)
         let sliceRange = try bounds.range(lastValidIndex: element.children.count - 1, path: path)
 
@@ -171,7 +172,7 @@ extension PathExplorerXML {
         if lastGroupSample != nil {
             slicedChildren = [AEXMLElement]()
             element.children.forEach { child in
-                let newChild = AEXMLElement(name: child.name, value: child.value, attributes: child.attributes)
+                let newChild = child.copy()
                 let newSlicedChildren = Array(child.children[sliceRange])
                 newChild.addChildren(newSlicedChildren)
                 slicedChildren.append(newChild)
@@ -190,7 +191,7 @@ extension PathExplorerXML {
         let filter = PathElement.filter(pattern)
         let path = readingPath.appending(filter)
         let regex = try NSRegularExpression(pattern: pattern, path: path)
-        let filterName = Path.defaultSeparator + PathElement.filter(pattern).description
+        let filterName = GroupSample.keySeparator + GroupSample.dictionaryFilter(pattern).description
 
         var filteredChildren = [AEXMLElement]()
 

--- a/Sources/Scout/Implementations/XML/PathExplorerXML+Get.swift
+++ b/Sources/Scout/Implementations/XML/PathExplorerXML+Get.swift
@@ -57,7 +57,7 @@ extension PathExplorerXML {
         try element.children.forEach { child in
             let pathExplorer = PathExplorerXML(element: child, path: readingPath.appending(child.name))
             let newChild = try pathExplorer.getSingle(at: index)
-            newChild.name = child.name + GroupSample.keySeparator + "index(\(index))"
+            newChild.name = child.name + GroupSample.keySeparator + GroupSample.indexDescription(index)
             copy.addChild(newChild)
         }
 

--- a/Sources/ScoutCLT/Add/AddCommand.swift
+++ b/Sources/ScoutCLT/Add/AddCommand.swift
@@ -60,17 +60,17 @@ struct AddCommand: ParsableCommand {
         if var json = try? Json(data: data) {
 
             try add(pathsAndValues, to: &json)
-            try ScoutCommand.output(output, dataWith: json, verbose: verbose, colorise: color.colorise, level: level, csv: separator)
+            try ScoutCommand.output(output, dataWith: json, verbose: verbose, colorise: color.colorise, level: level, csvSeparator: separator)
 
         } else if var plist = try? Plist(data: data) {
 
             try add(pathsAndValues, to: &plist)
-            try ScoutCommand.output(output, dataWith: plist, verbose: verbose, colorise: color.colorise, level: level, csv: separator)
+            try ScoutCommand.output(output, dataWith: plist, verbose: verbose, colorise: color.colorise, level: level, csvSeparator: separator)
 
         } else if var xml = try? Xml(data: data) {
 
             try add(pathsAndValues, to: &xml)
-            try ScoutCommand.output(output, dataWith: xml, verbose: verbose, colorise: color.colorise, level: level, csv: separator)
+            try ScoutCommand.output(output, dataWith: xml, verbose: verbose, colorise: color.colorise, level: level, csvSeparator: separator)
 
         } else {
             if let filePath = inputFilePath {

--- a/Sources/ScoutCLT/Add/AddCommand.swift
+++ b/Sources/ScoutCLT/Add/AddCommand.swift
@@ -25,9 +25,6 @@ struct AddCommand: ParsableCommand {
     @Option(name: [.short, .customLong("modify")], help: "Read and write the data into the same file at the given path", completion: .file())
     var modifyFilePath: String?
 
-    @Flag(name: [.short, .long], inversion: .prefixedNo, help: "Output the modified data")
-    var verbose = false
-
     @Flag(help: "Highlight the ouput. --no-color or --nc to prevent it")
     var color = ColorFlag.color
 
@@ -60,17 +57,17 @@ struct AddCommand: ParsableCommand {
         if var json = try? Json(data: data) {
 
             try add(pathsAndValues, to: &json)
-            try ScoutCommand.output(output, dataWith: json, verbose: verbose, colorise: color.colorise, level: level, csvSeparator: separator)
+            try ScoutCommand.output(output, dataWith: json, colorise: color.colorise, level: level, csvSeparator: separator)
 
         } else if var plist = try? Plist(data: data) {
 
             try add(pathsAndValues, to: &plist)
-            try ScoutCommand.output(output, dataWith: plist, verbose: verbose, colorise: color.colorise, level: level, csvSeparator: separator)
+            try ScoutCommand.output(output, dataWith: plist, colorise: color.colorise, level: level, csvSeparator: separator)
 
         } else if var xml = try? Xml(data: data) {
 
             try add(pathsAndValues, to: &xml)
-            try ScoutCommand.output(output, dataWith: xml, verbose: verbose, colorise: color.colorise, level: level, csvSeparator: separator)
+            try ScoutCommand.output(output, dataWith: xml, colorise: color.colorise, level: level, csvSeparator: separator)
 
         } else {
             if let filePath = inputFilePath {

--- a/Sources/ScoutCLT/Add/AddDocumentation.swift
+++ b/Sources/ScoutCLT/Add/AddDocumentation.swift
@@ -64,6 +64,7 @@ struct AddDocumentation: Documentation {
     - Deactivate the output colorization with \(noColor) or \(nc).
         Useful if you encounter slowdowns when dealing with large files although it is not recommended to ouput large files in the terminal.
     - Output an array or a dictionary of arrays with the \(csv) flag or \(csvSep) option
+    - Fold the arrays and dictionaries at a certain depth level with the \(level) option
 
     Examples
     --------

--- a/Sources/ScoutCLT/Add/AddDocumentation.swift
+++ b/Sources/ScoutCLT/Add/AddDocumentation.swift
@@ -60,7 +60,6 @@ struct AddDocumentation: Documentation {
     - When adding an element in an array, use the index -1 to add the element at the end of the array
 
     - You can add multiple values in one command
-    - Specify the \(verbose) flag to see the modified data
     - Deactivate the output colorization with \(noColor) or \(nc).
         Useful if you encounter slowdowns when dealing with large files although it is not recommended to ouput large files in the terminal.
     - Output an array or a dictionary of arrays with the \(csv) flag or \(csvSep) option

--- a/Sources/ScoutCLT/Delete/DeleteCommand.swift
+++ b/Sources/ScoutCLT/Delete/DeleteCommand.swift
@@ -70,17 +70,17 @@ struct DeleteCommand: ParsableCommand {
         if var json = try? Json(data: data) {
 
             try readingPaths.forEach { try json.delete($0, deleteIfEmpty: recursive) }
-            try ScoutCommand.output(output, dataWith: json, verbose: verbose, colorise: color.colorise, level: level, csv: separator)
+            try ScoutCommand.output(output, dataWith: json, verbose: verbose, colorise: color.colorise, level: level, csvSeparator: separator)
 
         } else if var plist = try? Plist(data: data) {
 
             try readingPaths.forEach { try plist.delete($0, deleteIfEmpty: recursive) }
-            try ScoutCommand.output(output, dataWith: plist, verbose: verbose, colorise: color.colorise, level: level, csv: separator)
+            try ScoutCommand.output(output, dataWith: plist, verbose: verbose, colorise: color.colorise, level: level, csvSeparator: separator)
 
         } else if var xml = try? Xml(data: data) {
 
             try readingPaths.forEach { try xml.delete($0, deleteIfEmpty: recursive) }
-            try ScoutCommand.output(output, dataWith: xml, verbose: verbose, colorise: color.colorise, level: level, csv: separator)
+            try ScoutCommand.output(output, dataWith: xml, verbose: verbose, colorise: color.colorise, level: level, csvSeparator: separator)
 
         } else {
             if let filePath = inputFilePath {

--- a/Sources/ScoutCLT/Delete/DeleteCommand.swift
+++ b/Sources/ScoutCLT/Delete/DeleteCommand.swift
@@ -30,9 +30,6 @@ struct DeleteCommand: ParsableCommand {
     @Option(name: [.short, .customLong("modify")], help: "Read and write the data into the same file at the given path", completion: .file())
     var modifyFilePath: String?
 
-    @Flag(name: [.short, .long], inversion: .prefixedNo, help: "Output the modified data")
-    var verbose = false
-
     @Flag(help: "Highlight the ouput. --no-color or --nc to prevent it")
     var color = ColorFlag.color
 
@@ -70,17 +67,17 @@ struct DeleteCommand: ParsableCommand {
         if var json = try? Json(data: data) {
 
             try readingPaths.forEach { try json.delete($0, deleteIfEmpty: recursive) }
-            try ScoutCommand.output(output, dataWith: json, verbose: verbose, colorise: color.colorise, level: level, csvSeparator: separator)
+            try ScoutCommand.output(output, dataWith: json, colorise: color.colorise, level: level, csvSeparator: separator)
 
         } else if var plist = try? Plist(data: data) {
 
             try readingPaths.forEach { try plist.delete($0, deleteIfEmpty: recursive) }
-            try ScoutCommand.output(output, dataWith: plist, verbose: verbose, colorise: color.colorise, level: level, csvSeparator: separator)
+            try ScoutCommand.output(output, dataWith: plist, colorise: color.colorise, level: level, csvSeparator: separator)
 
         } else if var xml = try? Xml(data: data) {
 
             try readingPaths.forEach { try xml.delete($0, deleteIfEmpty: recursive) }
-            try ScoutCommand.output(output, dataWith: xml, verbose: verbose, colorise: color.colorise, level: level, csvSeparator: separator)
+            try ScoutCommand.output(output, dataWith: xml, colorise: color.colorise, level: level, csvSeparator: separator)
 
         } else {
             if let filePath = inputFilePath {

--- a/Sources/ScoutCLT/Delete/DeleteDocumentation.swift
+++ b/Sources/ScoutCLT/Delete/DeleteDocumentation.swift
@@ -61,7 +61,6 @@ struct DeleteDocumentation: Documentation {
 
     - You can delete multiple values in one command
     - If the path is invalid, the program will return an error
-    - Specify the \(verbose) flag to see the modified data
     - Deactivate the output colorization with \(noColor) or \(nc).
         Useful if you encounter slowdowns when dealing with large files although it is not recommended to ouput large files in the terminal.
     - Output an array or a dictionary of arrays with the \(csv) flag or \(csvSep) option

--- a/Sources/ScoutCLT/Delete/DeleteDocumentation.swift
+++ b/Sources/ScoutCLT/Delete/DeleteDocumentation.swift
@@ -65,6 +65,7 @@ struct DeleteDocumentation: Documentation {
     - Deactivate the output colorization with \(noColor) or \(nc).
         Useful if you encounter slowdowns when dealing with large files although it is not recommended to ouput large files in the terminal.
     - Output an array or a dictionary of arrays with the \(csv) flag or \(csvSep) option
+    - Fold the arrays and dictionaries at a certain depth level with the \(level) option
 
     Examples
     --------

--- a/Sources/ScoutCLT/Main/ScoutCommand.swift
+++ b/Sources/ScoutCLT/Main/ScoutCommand.swift
@@ -43,7 +43,7 @@ struct ScoutCommand: ParsableCommand {
 
     // MARK: - Functions
 
-    static func output<T: PathExplorer>(_ output: String?, dataWith pathExplorer: T, verbose: Bool, colorise: Bool, level: Int? = nil, csvSeparator: String? = nil) throws {
+    static func output<T: PathExplorer>(_ output: String?, dataWith pathExplorer: T, colorise: Bool, level: Int? = nil, csvSeparator: String? = nil) throws {
 
         var csv: String?
         if let separator = csvSeparator {
@@ -54,10 +54,10 @@ struct ScoutCommand: ParsableCommand {
             let fm = FileManager.default
             let contents = try csv?.data(using: .utf8) ?? pathExplorer.exportData()
             fm.createFile(atPath: output, contents: contents, attributes: nil)
+            return
         }
 
         // remaining part to output the data
-        guard verbose else { return }
 
         // get the injector to inject color if necessary
         let injector: TextInjector
@@ -86,6 +86,11 @@ struct ScoutCommand: ParsableCommand {
             injector = xmlInjector
         }
 
+        if let csvOutput = csv {
+            print(csvOutput)
+            return
+        }
+
         // shadow variable to fold if necessary
         var pathExplorer = pathExplorer
 
@@ -93,14 +98,10 @@ struct ScoutCommand: ParsableCommand {
         if let level = level {
             pathExplorer.fold(upTo: level)
         }
-
-        if let csvOutput = csv {
-            print(csvOutput)
-        } else {
-            var output = try pathExplorer.exportString()
-            output = colorise ? injector.inject(in: output) : output
-            print(output)
-        }
+        
+        var output = try pathExplorer.exportString()
+        output = colorise ? injector.inject(in: output) : output
+        print(output)
     }
 
     static func getColorFile() throws -> ColorFile? {

--- a/Sources/ScoutCLT/Models/Documentation.swift
+++ b/Sources/ScoutCLT/Models/Documentation.swift
@@ -18,6 +18,7 @@ extension Documentation {
     static var csv: String { zshInjector.delegate.inject(.optionNameOrFlag, in: .terminal, "--csv") }
     static var csvSep: String { zshInjector.delegate.inject(.optionNameOrFlag, in: .terminal, "--csv-sep") }
     static var verbose: String { zshInjector.delegate.inject(.optionNameOrFlag, in: .terminal, "-v") }
+    static var level: String { zshInjector.delegate.inject(.optionNameOrFlag, in: .terminal, "-l") }
 
     /// Get one example per line
     /// - Parameters:

--- a/Sources/ScoutCLT/Models/Documentation.swift
+++ b/Sources/ScoutCLT/Models/Documentation.swift
@@ -17,7 +17,6 @@ extension Documentation {
     static var nc: String { zshInjector.delegate.inject(.optionNameOrFlag, in: .terminal, "--nc") }
     static var csv: String { zshInjector.delegate.inject(.optionNameOrFlag, in: .terminal, "--csv") }
     static var csvSep: String { zshInjector.delegate.inject(.optionNameOrFlag, in: .terminal, "--csv-sep") }
-    static var verbose: String { zshInjector.delegate.inject(.optionNameOrFlag, in: .terminal, "-v") }
     static var level: String { zshInjector.delegate.inject(.optionNameOrFlag, in: .terminal, "-l") }
 
     /// Get one example per line

--- a/Sources/ScoutCLT/Read/ReadDocumentation.swift
+++ b/Sources/ScoutCLT/Read/ReadDocumentation.swift
@@ -64,6 +64,7 @@ struct ReadDocumentation: Documentation {
     - Deactivate the output colorization with \(noColor) or \(nc).
         Useful to export the data or if you encounter slowdowns when dealing with large files ((although it is not recommended to ouput large files in the terminal).
     - Output an array or a dictionary of arrays with the \(csv) flag or \(csvSep) option
+    - Fold the arrays and dictionaries at a certain depth level with the \(level) option
 
     Examples
     --------

--- a/Sources/ScoutCLT/Set/SetCommand.swift
+++ b/Sources/ScoutCLT/Set/SetCommand.swift
@@ -69,17 +69,17 @@ struct SetCommand: ParsableCommand {
         if var json = try? Json(data: data) {
 
             try set(pathsAndValues, in: &json)
-            try ScoutCommand.output(output, dataWith: json, verbose: verbose, colorise: color.colorise, level: level, csv: separator)
+            try ScoutCommand.output(output, dataWith: json, verbose: verbose, colorise: color.colorise, level: level, csvSeparator: separator)
 
         } else if var plist = try? Plist(data: data) {
 
             try set(pathsAndValues, in: &plist)
-            try ScoutCommand.output(output, dataWith: plist, verbose: verbose, colorise: color.colorise, level: level, csv: separator)
+            try ScoutCommand.output(output, dataWith: plist, verbose: verbose, colorise: color.colorise, level: level, csvSeparator: separator)
 
         } else if var xml = try? Xml(data: data) {
 
             try set(pathsAndValues, in: &xml)
-            try ScoutCommand.output(output, dataWith: xml, verbose: verbose, colorise: color.colorise, level: level, csv: separator)
+            try ScoutCommand.output(output, dataWith: xml, verbose: verbose, colorise: color.colorise, level: level, csvSeparator: separator)
 
         } else {
             if let filePath = inputFilePath {

--- a/Sources/ScoutCLT/Set/SetCommand.swift
+++ b/Sources/ScoutCLT/Set/SetCommand.swift
@@ -32,9 +32,6 @@ struct SetCommand: ParsableCommand {
     @Option(name: [.short, .customLong("modify")], help: "Read and write the data into the same file at the given path", completion: .file())
     var modifyFilePath: String?
 
-    @Flag(name: [.short, .long], inversion: .prefixedNo, help: "Output the modified data")
-    var verbose = false
-
     @Flag(help: "Highlight the ouput. --no-color or --nc to prevent it")
     var color = ColorFlag.color
 
@@ -69,17 +66,17 @@ struct SetCommand: ParsableCommand {
         if var json = try? Json(data: data) {
 
             try set(pathsAndValues, in: &json)
-            try ScoutCommand.output(output, dataWith: json, verbose: verbose, colorise: color.colorise, level: level, csvSeparator: separator)
+            try ScoutCommand.output(output, dataWith: json, colorise: color.colorise, level: level, csvSeparator: separator)
 
         } else if var plist = try? Plist(data: data) {
 
             try set(pathsAndValues, in: &plist)
-            try ScoutCommand.output(output, dataWith: plist, verbose: verbose, colorise: color.colorise, level: level, csvSeparator: separator)
+            try ScoutCommand.output(output, dataWith: plist, colorise: color.colorise, level: level, csvSeparator: separator)
 
         } else if var xml = try? Xml(data: data) {
 
             try set(pathsAndValues, in: &xml)
-            try ScoutCommand.output(output, dataWith: xml, verbose: verbose, colorise: color.colorise, level: level, csvSeparator: separator)
+            try ScoutCommand.output(output, dataWith: xml, colorise: color.colorise, level: level, csvSeparator: separator)
 
         } else {
             if let filePath = inputFilePath {

--- a/Sources/ScoutCLT/Set/SetDocumentation.swift
+++ b/Sources/ScoutCLT/Set/SetDocumentation.swift
@@ -56,7 +56,6 @@ struct SetDocumentation: Documentation {
     - When accessing an array value by its index, use the index -1 to access to the last element
 
     - You can set multiple values in one command.
-    - Specify the \(verbose) flag to see the modified data
     - Deactivate the output colorization with \(noColor) or \(nc).
         Useful to export the data or if you encounter slowdowns when dealing with large files ((although it is not recommended to ouput large files in the terminal).
     - Output an array or a dictionary of arrays with the \(csv) flag or \(csvSep) option

--- a/Sources/ScoutCLT/Set/SetDocumentation.swift
+++ b/Sources/ScoutCLT/Set/SetDocumentation.swift
@@ -60,6 +60,7 @@ struct SetDocumentation: Documentation {
     - Deactivate the output colorization with \(noColor) or \(nc).
         Useful to export the data or if you encounter slowdowns when dealing with large files ((although it is not recommended to ouput large files in the terminal).
     - Output an array or a dictionary of arrays with the \(csv) flag or \(csvSep) option
+    - Fold the arrays and dictionaries at a certain depth level with the \(level) option
 
     Examples
     --------

--- a/Tests/ScoutTests/Implementations/Serialization/PathExplorerSerializationTests+Get.swift
+++ b/Tests/ScoutTests/Implementations/Serialization/PathExplorerSerializationTests+Get.swift
@@ -153,7 +153,7 @@ extension PathExplorerSerializationTests {
         plist = try plist.get(path)
 
         let resultValue = try XCTUnwrap(plist.value as? [String: [Int]])
-        XCTAssertEqual(["Buzz.episodes[1:2]": [2, 3], "Zurg.episodes[1:2]": [2, 3]], resultValue)
+        XCTAssertEqual(["Buzz_episodes_slice(1,2)": [2, 3], "Zurg_episodes_slice(1,2)": [2, 3]], resultValue)
     }
 
     func testGetDictionaryFilter() throws {
@@ -186,9 +186,9 @@ extension PathExplorerSerializationTests {
 
         let keys = try XCTUnwrap(value as? [String: String])
         var copy = [String: String]()
-        charactersByName.forEach { copy[$0.key + ".name"] = $0.value.name }
+        charactersByName.forEach { copy[$0.key + "_name"] = $0.value.name }
 
-        copy.removeValue(forKey: "Woody.name")
+        copy.removeValue(forKey: "Woody_name")
 
         XCTAssertEqual(keys, copy)
     }
@@ -201,7 +201,7 @@ extension PathExplorerSerializationTests {
 
         let keys = try XCTUnwrap(value as? [String: Int])
         var copy  = [String: Int]()
-        charactersByName.forEach { copy[$0.key + ".episodes[1]"] = $0.value.episodes[1] }
+        charactersByName.forEach { copy[$0.key + "_episodes_index(1)"] = $0.value.episodes[1] }
 
         XCTAssertEqual(keys, copy)
     }
@@ -236,9 +236,9 @@ extension PathExplorerSerializationTests {
         plist = try plist.get(path)
 
         let resultValue = try XCTUnwrap(plist.value as? [String: [String: [Int]]])
-        XCTAssertEqual(["Buzz#episodes#":
+        XCTAssertEqual(["Buzz_filter(episodes)":
                             ["episodes": [1, 2, 3]],
-                        "Zurg#episodes#":
+                        "Zurg_filter(episodes)":
                             ["episodes": [1, 2, 3]]],
                        resultValue)
     }

--- a/Tests/ScoutTests/Implementations/Serialization/PathExplorerSerializationTests.swift
+++ b/Tests/ScoutTests/Implementations/Serialization/PathExplorerSerializationTests.swift
@@ -90,7 +90,7 @@ final class PathExplorerSerializationTests: XCTestCase {
         let plist = try Plist(data: data)
 
         let csv = try plist.exportCSVArrayOfDictionaries(separator: ";")
-        let expectedHeaders = ["episodes[0]", "episodes[1]", "episodes[2]", "name", "quote"]
+        let expectedHeaders = ["episodes_index(0)", "episodes_index(1)", "episodes_index(2)", "name", "quote"]
         let expectedValues = [["1", "2", "3", "Woody", "I got a snake in my boot"],
                               ["1", "2", "3", "Buzz", "To infinity and beyond"],
                               ["1", "2", "3", "Zurg", "Destroy Buzz Lightyear"]]
@@ -104,9 +104,9 @@ final class PathExplorerSerializationTests: XCTestCase {
         let plist = try Plist(data: data)
 
         let csv = try plist.get(PathElement.filter(".*"), "episodes").exportCSVDictionary(separator: ";")
-        let expectedValues = [["Buzz.episodes", "1", "2", "3"],
-                              ["Woody.episodes", "1", "2", "3"],
-                              ["Zurg.episodes", "1", "2", "3"]]
+        let expectedValues = [["Buzz_episodes", "1", "2", "3"],
+                              ["Woody_episodes", "1", "2", "3"],
+                              ["Zurg_episodes", "1", "2", "3"]]
 
         XCTAssertEqual(csv.sorted { $0[0] < $1[0] }, expectedValues)
     }
@@ -139,6 +139,6 @@ final class PathExplorerSerializationTests: XCTestCase {
             names.insert(key)
         }
 
-        XCTAssertEqual(names, Set(arrayLiteral: "name", "quote", "episodes[0]", "episodes[1]", "episodes[2]"))
+        XCTAssertEqual(names, Set(arrayLiteral: "name", "quote", "episodes_index(0)", "episodes_index(1)", "episodes_index(2)"))
     }
 }

--- a/Tests/ScoutTests/Implementations/XML/PathExplorerXMLTests+Get.swift
+++ b/Tests/ScoutTests/Implementations/XML/PathExplorerXMLTests+Get.swift
@@ -111,8 +111,8 @@ extension PathExplorerXMLTests {
         try xml.get(path).element.children.forEach { value[$0.name] = $0.value }
 
         var quotes = [String: String]()
-        Character.charactersByName.forEach { quotes[$0.key + ".quote"] = $0.value.quote }
-        quotes.removeValue(forKey: "Woody.quote")
+        Character.charactersByName.forEach { quotes[$0.key + "_quote"] = $0.value.quote }
+        quotes.removeValue(forKey: "Woody_quote")
 
         XCTAssertEqual(quotes, value)
     }
@@ -125,8 +125,8 @@ extension PathExplorerXMLTests {
         try xml.get(path).element.children.forEach { value[$0.name] = $0.int }
 
         var episodes = [String: Int]()
-        Character.charactersByName.forEach { episodes[$0.key + ".episodes[1]"] = $0.value.episodes[1] }
-        episodes.removeValue(forKey: "Woody.episodes[1]")
+        Character.charactersByName.forEach { episodes[$0.key + "_episodes_index(1)"] = $0.value.episodes[1] }
+        episodes.removeValue(forKey: "Woody_episodes_index(1)")
 
         XCTAssertEqual(episodes, value)
     }
@@ -137,8 +137,8 @@ extension PathExplorerXMLTests {
 
         let element = try xml.get(path).element
 
-        XCTAssertEqual(element["Buzz.#episodes#"]["episodes"].children.count, 3)
-        XCTAssertEqual(element["Zurg.#episodes#"]["episodes"].children.count, 3)
+        XCTAssertEqual(element["Buzz_filter(episodes)"]["episodes"].children.count, 3)
+        XCTAssertEqual(element["Zurg_filter(episodes)"]["episodes"].children.count, 3)
     }
 
     // MARK: Array count

--- a/Tests/ScoutTests/Implementations/XML/PathExplorerXMLTests.swift
+++ b/Tests/ScoutTests/Implementations/XML/PathExplorerXMLTests.swift
@@ -188,9 +188,9 @@ final class PathExplorerXMLTests: XCTestCase {
 
         let (headers, values) = try xml.get("characters", PathElement.filter(".*"), "episodes").exportCSVHeadersAndValues(separator: ";")
 
-        let expectedValues = [["Buzz.episodes", "1", "2", "3"],
-                              ["Woody.episodes", "1", "2", "3"],
-                              ["Zurg.episodes", "1", "2", "3"]]
+        let expectedValues = [["Buzz_episodes", "1", "2", "3"],
+                              ["Woody_episodes", "1", "2", "3"],
+                              ["Zurg_episodes", "1", "2", "3"]]
 
         XCTAssertTrue(headers.isEmpty)
         XCTAssertEqual(values.sorted { $0[0] < $1[0] }, expectedValues)


### PR DESCRIPTION
- Dictionary filtering key names changed from path-like to underscore
- Updated in-line documentation
- **Deleted verbose option**. Default behavior is now to output the data if the output or modify option are not specified.