### PR TITLE
Path refactoring

### DIFF
--- a/Sources/Scout/Definitions/GroupSample.swift
+++ b/Sources/Scout/Definitions/GroupSample.swift
@@ -4,7 +4,7 @@
 // MIT license, see LICENSE file for details
 
 /// Array slice or dictionary filter found in a `Path`
-enum GroupSample: CustomStringConvertible {
+enum GroupSample {
     case arraySlice(Bounds)
     case dictionaryFilter(String)
 
@@ -16,13 +16,6 @@ enum GroupSample: CustomStringConvertible {
         switch self {
         case .arraySlice: return "an Array"
         case .dictionaryFilter: return "a Dictionary"
-        }
-    }
-
-    var description: String {
-        switch self {
-        case .arraySlice(let bounds): return "slice(\(bounds.lowerString),\(bounds.upperString))"
-        case .dictionaryFilter(let pattern): return "filter(\(pattern))"
         }
     }
 

--- a/Sources/Scout/Definitions/PathElement.swift
+++ b/Sources/Scout/Definitions/PathElement.swift
@@ -72,8 +72,12 @@ public enum PathElement: Equatable {
     // MARK: - Initialization
 
     init(from string: String) {
-        if let index = Int(string) {
-            self = .index(index)
+        if let index = string.index {
+            self = index
+        } else if let count = string.count {
+            self = count
+        } else if let keysList = string.keysList {
+            self = keysList
         } else if string == Self.defaultCountSymbol {
             self = .count
         } else if let range = string.slice {

--- a/Sources/Scout/Definitions/PathElement.swift
+++ b/Sources/Scout/Definitions/PathElement.swift
@@ -53,8 +53,8 @@ public enum PathElement: Equatable {
     /// Can subscript an array or a dictionay
     public var isGroupSubscripter: Bool {
         switch self {
-        case .count, .index, .slice, .filter: return true
-        case .key, .keysList: return false
+        case .count, .keysList, .index, .slice, .filter: return true
+        case .key: return false
         }
     }
 
@@ -117,6 +117,18 @@ extension PathElement: CustomStringConvertible {
 
         case .filter(let filter):
             return "#\(filter)#"
+        }
+    }
+
+    /// Name of the path element when used a key
+    var keyName: String {
+        switch self {
+        case .key(let key): return key
+        case .index(let index): return "index\(index))"
+        case .count: return "count"
+        case .keysList: return "keysList"
+        case .slice(let bounds): return "slice(\(bounds.lowerString),\(bounds.upperString))"
+        case .filter(let pattern): return "filter(\(pattern))"
         }
     }
 }

--- a/Sources/Scout/Definitions/PathElementRepresentable.swift
+++ b/Sources/Scout/Definitions/PathElementRepresentable.swift
@@ -24,10 +24,45 @@ public protocol PathElementRepresentable {
 }
 
 extension String: PathElementRepresentable {
-    public var pathValue: PathElement { slice ?? filter ?? .key(self) }
+    public var pathValue: PathElement { index ?? count ?? keysList ?? slice ?? filter ?? .key(self) }
+
+    var index: PathElement? {
+        guard self.hasPrefix("["), self.hasSuffix("]") else {
+            return nil
+        }
+
+        var copy = self
+        copy.removeFirst()
+        copy.removeLast()
+
+        guard let index = Int(copy) else { return nil }
+        return PathElement.index(index)
+    }
+
+    var count: PathElement? {
+        if self == PathElement.count.description {
+            return .count
+        }
+        return nil
+    }
+
+    var keysList: PathElement? {
+        if self == PathElement.keysList.description {
+            return .keysList
+        }
+        return nil
+    }
 
     var slice: PathElement? {
-        let splitted = components(separatedBy: ":")
+        guard self.hasPrefix("["), self.hasSuffix("]") else {
+            return nil
+        }
+
+        var copy = self
+        copy.removeFirst()
+        copy.removeLast()
+
+        let splitted = copy.components(separatedBy: ":")
 
         guard splitted.count == 2 else {
             return nil

--- a/Sources/Scout/Implementations/Serialization/PathExplorerSerialization+Get.swift
+++ b/Sources/Scout/Implementations/Serialization/PathExplorerSerialization+Get.swift
@@ -186,7 +186,7 @@ extension PathExplorerSerialization {
             guard let count = try pathExplorer.getChildrenCountSimple().int else {
                 throw PathExplorerError.wrongUsage(of: .count, in: path)
             }
-            countsDict[key + PathElement.count.description] = count
+        countsDict[key + GroupSample.keySeparator + PathElement.count.keyName] = count
         }
         return PathExplorerSerialization(value: countsDict, path: readingPath.appending(.count))
     }
@@ -293,7 +293,7 @@ extension PathExplorerSerialization {
             let path = readingPath.appending(key)
             let pathExplorer = PathExplorerSerialization(value: value, path: path)
             let filteredDict = try pathExplorer.getSingle(groupSample).value
-            let newName = detailedName ? key + GroupSample.keySeparator + groupSample.description : key
+            let newName = detailedName ? key + GroupSample.keySeparator + groupSample.pathElement.keyName : key
             newDict[newName] = filteredDict
         }
 

--- a/Sources/Scout/Implementations/XML/PathExplorerXML+Get.swift
+++ b/Sources/Scout/Implementations/XML/PathExplorerXML+Get.swift
@@ -118,6 +118,8 @@ extension PathExplorerXML {
         return copy
     }
 
+    // MARK: - Count
+
     func getChildrenCount() throws -> Self {
         if let sample = lastGroupSample {
             let copy = AEXMLElement(name: element.name + PathElement.count.description)
@@ -126,7 +128,7 @@ extension PathExplorerXML {
                 let name: String
 
                 switch sample {
-                case .dictionaryFilter: name = child.name + PathElement.count.description
+                case .dictionaryFilter: name = child.name + GroupSample.keySeparator + PathElement.count.keyName
                 case .arraySlice: name = child.name
                 }
 
@@ -139,6 +141,8 @@ extension PathExplorerXML {
         return PathExplorerXML(element: .init(name: "", value: "\(self.element.children.count)", attributes: [:]),
                                path: readingPath.appending(.count))
     }
+
+    // MARK: - Keys list
 
     func getKeysList() throws -> Self {
         var keyChildren = [AEXMLElement]()
@@ -162,7 +166,7 @@ extension PathExplorerXML {
     func getArraySlice(within bounds: Bounds) throws -> PathExplorerXML {
         let slice = PathElement.slice(bounds)
         // we have to copy the element as we cannot modify its children
-        let newKeyName = element.name + GroupSample.keySeparator + GroupSample.arraySlice(bounds).description
+        let newKeyName = element.name + GroupSample.keySeparator + slice.keyName
         let copy = AEXMLElement(name: newKeyName, value: element.value, attributes: element.attributes)
         let path = readingPath.appending(slice)
         let sliceRange = try bounds.range(lastValidIndex: element.children.count - 1, path: path)
@@ -191,7 +195,7 @@ extension PathExplorerXML {
         let filter = PathElement.filter(pattern)
         let path = readingPath.appending(filter)
         let regex = try NSRegularExpression(pattern: pattern, path: path)
-        let filterName = GroupSample.keySeparator + GroupSample.dictionaryFilter(pattern).description
+        let filterName = GroupSample.keySeparator + filter.keyName
 
         var filteredChildren = [AEXMLElement]()
 

--- a/Sources/ScoutCLT/Main/ScoutCommand.swift
+++ b/Sources/ScoutCLT/Main/ScoutCommand.swift
@@ -98,7 +98,7 @@ struct ScoutCommand: ParsableCommand {
         if let level = level {
             pathExplorer.fold(upTo: level)
         }
-        
+
         var output = try pathExplorer.exportString()
         output = colorise ? injector.inject(in: output) : output
         print(output)

--- a/Tests/ScoutTests/Definitions/PathTests.swift
+++ b/Tests/ScoutTests/Definitions/PathTests.swift
@@ -15,12 +15,11 @@ final class PathTests: XCTestCase {
     let index = 1
     let secondKeyWithIndex = "secondKey[1]"
     let secondKeyWithNegativeIndex = "secondKey[-1]"
-    let secondKeyWithdot = "second.key"
+    let secondKeyWithDot = "second.key"
     let secondKeyWithDotAndIndex = "second.key[1]"
     let secondKeyWithFourthSeparator = "second$key"
     let secondKeyWithNestedArray = "secondKey[1][0]"
     let secondKeyWithTwoNestedArrays = "secondKey[1][0][2]"
-    let secondKeyWithFourthSeparatorAndIndex = "second$key[1]"
     let secondKeyWithCount = "secondKey[#]"
     let secondKeyWithKeysList = "secondKey{#}"
     let secondKeyWithFullRange = "secondKey[2:4]"
@@ -75,8 +74,8 @@ final class PathTests: XCTestCase {
     }
 
     func testKeysWithBracketsAndIndex() throws {
-        let array: Path = [firstKey, secondKeyWithdot, 1, thirdKey]
-        let path = try Path(string: "\(firstKey).(\(secondKeyWithDotAndIndex)).\(thirdKey)")
+        let array: Path = [firstKey, secondKeyWithDot, 1, thirdKey]
+        let path = try Path(string: "\(firstKey).(\(secondKeyWithDot))[1]\(thirdKey)")
 
         XCTAssertEqual(path, array)
     }
@@ -118,7 +117,7 @@ final class PathTests: XCTestCase {
 
     func testSeparator3WithBracketAndIndex() throws {
         let array: Path = [firstKey, secondKeyWithFourthSeparator, index, thirdKey]
-        let path = try Path(string: "\(firstKey)$(\(secondKeyWithFourthSeparatorAndIndex))$\(thirdKey)", separator: fourthSeparator)
+        let path = try Path(string: "\(firstKey)$(\(secondKeyWithFourthSeparator))[\(index)]$\(thirdKey)", separator: fourthSeparator)
 
         XCTAssertEqual(path, array)
     }
@@ -165,6 +164,13 @@ final class PathTests: XCTestCase {
     func testKeysListFirstElement() throws {
         let array: Path = [PathElement.keysList, 1]
         let path = try Path(string: "{#}[1]")
+
+        XCTAssertEqual(path, array)
+    }
+
+    func testKeysListAfterIndex() throws {
+        let array: Path = ["hello", 1, PathElement.keysList]
+        let path = try Path(string: "hello[1]{#}")
 
         XCTAssertEqual(path, array)
     }

--- a/Tests/ScoutTests/Implementations/Serialization/PathExplorerSerializationTests+Get.swift
+++ b/Tests/ScoutTests/Implementations/Serialization/PathExplorerSerializationTests+Get.swift
@@ -214,7 +214,7 @@ extension PathExplorerSerializationTests {
         plist = try plist.get(path)
 
         let resultValue = try XCTUnwrap(plist.value as? [String: Int])
-        XCTAssertEqual(["Buzz[#]": 3, "Zurg[#]": 3], resultValue)
+        XCTAssertEqual(["Buzz_count": 3, "Zurg_count": 3], resultValue)
     }
 
     func testGetDictionaryFilterArraySlice() throws {

--- a/Tests/ScoutTests/Implementations/XML/PathExplorerXMLTests+Get.swift
+++ b/Tests/ScoutTests/Implementations/XML/PathExplorerXMLTests+Get.swift
@@ -149,6 +149,16 @@ extension PathExplorerXMLTests {
         XCTAssertEqual(try xml.get(for: "dogs").get(element: .count).int, 3)
     }
 
+    func testGetCountDictionaryFilter() throws {
+        let xml = try Xml(data: toyBoxByName)
+
+        let element = try xml.get("characters", PathElement.filter(".*"), PathElement.count).element
+
+        XCTAssertEqual(element["Woody_count"].int, 3)
+        XCTAssertEqual(element["Buzz_count"].int, 3)
+        XCTAssertEqual(element["Zurg_count"].int, 3)
+    }
+
     func testGetCount_ThrowsErrorIfNotFinal() throws {
         let xml = try Xml(data: stubData2)
         let errorPath = Path("root", "dogs", PathElement.count)


### PR DESCRIPTION
- Initialisation from string now uses the `PathElement` `init(from:)` to get the element. New string extensons added for this purpose
- Count replaced by _count in keys names