### PR TITLE
[#147] PathExplorer delete key pattern

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/tadija/AEXML.git",
         "state": {
           "branch": null,
-          "revision": "502c4d43a6cc9c395d19111e09dc62ad834977b5",
-          "version": "4.6.0"
+          "revision": "8623e73b193386909566a9ca20203e33a09af142",
+          "version": "4.5.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/JohnSundell/Splash",
         "state": {
           "branch": null,
-          "revision": "81de0389558ad40579027735841593b21a511fa8",
-          "version": "0.15.0"
+          "revision": "f25dd8c9f16be1f81a152f6861d7216c3c9302da",
+          "version": "0.14.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "9564d61b08a5335ae0a36f789a7d71493eacadfc",
-          "version": "0.3.2"
+          "revision": "92646c0cdbaca076c8d3d0207891785b3379cbff",
+          "version": "0.3.1"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "9003d51672e516cc59297b7e96bff1dfdedcb4ea",
-          "version": "4.0.4"
+          "revision": "88caa2e6fffdbef2e91c2022d038576062042907",
+          "version": "4.0.0"
         }
       }
     ]

--- a/Sources/Scout/Definitions/PathExplorer+Extensions.swift
+++ b/Sources/Scout/Definitions/PathExplorer+Extensions.swift
@@ -84,6 +84,8 @@ public extension PathExplorer {
 
 extension PathExplorer {
 
+    public var double: Double? { real }
+
     /// Ensure a value as a correct type
     /// - Parameter value: The value to convert
     /// - Parameter type: The type to use to convert the value. Use `automatic` to let the function try the available types

--- a/Sources/Scout/Definitions/PathExplorer.swift
+++ b/Sources/Scout/Definitions/PathExplorer.swift
@@ -112,6 +112,10 @@ where
     /// - Throws: If the path is invalid (e.g. a key does not exist in a dictionary, or indicating an index on a non-array key)
     mutating func delete(_ path: PathElementRepresentable..., deleteIfEmpty: Bool) throws
 
+    /// Delete all the keys matching the regular expression pattern
+    /// - parameter deleteIfEmpty: When `true`, the dictionary or array holding the value will be deleted too if empty after the key deletion
+    mutating func delete(regularExpression: NSRegularExpression, deleteIfEmpty: Bool) throws
+
     // MARK: Add
 
     /**

--- a/Sources/Scout/Implementations/XML/PathExplorerXML+Delete.swift
+++ b/Sources/Scout/Implementations/XML/PathExplorerXML+Delete.swift
@@ -88,4 +88,22 @@ extension PathExplorerXML {
 
         explorers = newElementsToDelete
     }
+
+    // MARK: - Regular expression
+
+    public mutating func delete(regularExpression: NSRegularExpression, deleteIfEmpty: Bool) throws {
+        element.children
+            .filter { regularExpression.validate($0.name) }
+            .forEach { $0.removeFromParent() }
+
+        try element.children.forEach { (child) in
+            var explorer = PathExplorerXML(element: child, path: readingPath)
+            try explorer.delete(regularExpression: regularExpression, deleteIfEmpty: deleteIfEmpty)
+        }
+
+        if deleteIfEmpty, element.children.isEmpty,
+           (element.value == nil || element.string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == true) {
+            element.removeFromParent()
+        }
+    }
 }

--- a/Sources/ScoutCLT/Delete/DeleteKeyCommand.swift
+++ b/Sources/ScoutCLT/Delete/DeleteKeyCommand.swift
@@ -3,23 +3,25 @@
 // Copyright (c) Alexis Bridoux 2020
 // MIT license, see LICENSE file for details
 
-import ArgumentParser
-import Scout
 import Foundation
+import Scout
+import ArgumentParser
 
-struct DeleteCommand: SADCommand {
+struct DeleteKeyCommand: SADCommand {
 
     // MARK: - Constants
 
     static let configuration = CommandConfiguration(
-        commandName: "delete",
-        abstract: "Delete a value at a given path",
-        discussion: "To find examples and advanced explanations, please type `scout doc -c delete-key`")
+        commandName: "delete-key",
+        abstract: "Delete all the (key, value) pairs where the key matches the regular expression pattern",
+        discussion: "To find examples and advanced explanations, please type `scout doc -c delete`")
 
     // MARK: - Properties
 
-    @Argument(help: "Paths to indicate the keys to be deleted")
-    var pathsCollection = [Path]()
+    var pathsCollection: [Path] { [Path("empty")] }
+
+    @Argument(help: "The regular expression pattern the keys to delete have to match")
+    var pattern: String
 
     @Option(name: [.short, .customLong("input")], help: "A file path from which to read the data", completion: .file())
     var inputFilePath: String?
@@ -51,6 +53,8 @@ struct DeleteCommand: SADCommand {
     // MARK: - Functions
 
     func perform<P: PathExplorer>(pathExplorer: inout P, pathCollectionElement: Path) throws {
-        try pathExplorer.delete(pathCollectionElement, deleteIfEmpty: recursive)
+        // will be called only once
+        let regularExpression = try NSRegularExpression(pattern: pattern)
+        try pathExplorer.delete(regularExpression: regularExpression, deleteIfEmpty: recursive)
     }
 }

--- a/Sources/ScoutCLT/Main/DocCommand.swift
+++ b/Sources/ScoutCLT/Main/DocCommand.swift
@@ -120,6 +120,8 @@ static let configuration = CommandConfiguration(
             case .read: print(ReadDocumentation.text)
             case .set: print(SetDocumentation.text)
             case .delete: print(DeleteDocumentation.text)
+                #warning("Update doc for DeleteKey command")
+            case .deleteKey: print(DeleteDocumentation.text)
             case .add: print(AddDocumentation.text)
             }
         } else {

--- a/Sources/ScoutCLT/Main/ScoutCommand.swift
+++ b/Sources/ScoutCLT/Main/ScoutCommand.swift
@@ -38,6 +38,7 @@ struct ScoutCommand: ParsableCommand {
                 DeleteCommand.self,
                 AddCommand.self,
                 DocCommand.self,
+                DeleteKeyCommand.self,
                 InstallCompletionScriptCommand.self],
             defaultSubcommand: ReadCommand.self)
 

--- a/Sources/ScoutCLT/Models/Command.swift
+++ b/Sources/ScoutCLT/Models/Command.swift
@@ -6,7 +6,7 @@
 import ArgumentParser
 
 enum Command: String, ExpressibleByArgument, CaseIterable {
-    case read, set, delete, add
+    case read, set, delete, deleteKey, add
 
     static var documentationDescription: String {
         "\(Self.read.rawValue.mainColor), \(Self.set.rawValue.mainColor), \(Self.delete.rawValue.mainColor) and \(Self.add.rawValue.mainColor)"

--- a/Sources/ScoutCLT/Models/SADCommand.swift
+++ b/Sources/ScoutCLT/Models/SADCommand.swift
@@ -41,6 +41,11 @@ extension SADCommand {
     }
 
     func run() throws {
+        try defaultRun()
+    }
+
+    /// The default run function implementation for a SAD command
+    func defaultRun() throws {
         let data = try readDataOrInputStream(from: modifyFilePath ?? inputFilePath)
         let outputPath = modifyFilePath ?? outputFilePath
 

--- a/Tests/ScoutTests/Implementations/Serialization/PathExplorerSerializationTests+Delete.swift
+++ b/Tests/ScoutTests/Implementations/Serialization/PathExplorerSerializationTests+Delete.swift
@@ -238,4 +238,43 @@ extension PathExplorerSerializationTests {
         XCTAssertErrorsEqual(try plist.get("Buzz", "episodes"), .subscriptMissingKey(path: Path("Buzz"), key: "episodes", bestMatch: nil))
         XCTAssertErrorsEqual(try plist.get("Zurg", "episodes"), .subscriptMissingKey(path: Path("Zurg"), key: "episodes", bestMatch: nil))
     }
+
+    // MARK: - Regex pattern
+
+    func testDeleteKeyRegexPattern() throws {
+        let attributesKey = "attributes"
+        let attributes = ["duration": 20, "score": 500]
+        var games = [String: Any]()
+        games[attributesKey] = attributes
+        var firstPlayer: [String: Any] = ["name": "John", "rank": 1]
+        firstPlayer[attributesKey] = attributes
+        var secondPlayer: [String: Any] = ["name": "Maeva", "rank": 1]
+        secondPlayer[attributesKey] = attributes
+        games["players"] = [firstPlayer, secondPlayer]
+        var explorer = Plist(value: games)
+        let regex = try NSRegularExpression(pattern: "attributes")
+
+        try explorer.delete(regularExpression: regex, deleteIfEmpty: false)
+
+        XCTAssertErrorsEqual(try explorer.get("attributes"), .subscriptMissingKey(path: .empty, key: "attributes", bestMatch: nil))
+        XCTAssertErrorsEqual(try explorer.get("players", 0, "attributes"), .subscriptMissingKey(path: Path("players", 0), key: "attributes", bestMatch: nil))
+        XCTAssertErrorsEqual(try explorer.get("players", 1, "attributes"), .subscriptMissingKey(path: Path("players", 1), key: "attributes", bestMatch: nil))
+    }
+
+    func testDeleteKeyRegexPatternDeleteIfEmpty() throws {
+        let attributesKey = "attributes"
+        let attributes = ["duration": 20, "score": 500]
+        var games = [String: Any]()
+        games[attributesKey] = attributes
+        let firstPlayer = [attributesKey: attributes]
+        let secondPlayer = [attributesKey: attributes]
+        games["players"] = [firstPlayer, secondPlayer]
+        var explorer = Plist(value: games)
+        let regex = try NSRegularExpression(pattern: "attributes")
+
+        try explorer.delete(regularExpression: regex, deleteIfEmpty: true)
+
+        XCTAssertErrorsEqual(try explorer.get("attributes"), .subscriptMissingKey(path: .empty, key: "attributes", bestMatch: nil))
+        XCTAssertErrorsEqual(try explorer.get("players"), .subscriptMissingKey(path: .empty, key: "players", bestMatch: nil))
+    }
 }

--- a/Tests/ScoutTests/Implementations/XML/PathExplorerXMLTests + SerializationExport.swift
+++ b/Tests/ScoutTests/Implementations/XML/PathExplorerXMLTests + SerializationExport.swift
@@ -207,7 +207,7 @@ final class PathExplorerXMLSerializationExportTests: XCTestCase {
 extension PathExplorerXMLSerializationExportTests {
 
     func serialize(element: AEXMLElement) -> Any {
-        let explorer = PathExplorerXML(element: element, path: Path([]))
+        let explorer = PathExplorerXML(element: element, path: .empty)
         return explorer.serialize(element: element)
     }
 }


### PR DESCRIPTION
Closes #147 

Delete all the (key, value) pair where the key matches the regular expression pattern.
- Added a new SAD command `delete-ke` for that: `scout delete-key "pattern"`