### PR TITLE
[#171] Path collections protocol

### DIFF
--- a/Sources/Scout/Models/Path/Collection+Path.swift
+++ b/Sources/Scout/Models/Path/Collection+Path.swift
@@ -1,0 +1,38 @@
+//
+// Scout
+// Copyright (c) Alexis Bridoux 2020
+// MIT license, see LICENSE file for details
+
+import Foundation
+
+public extension Collection where Element == Path {
+
+    /// Sort by key or index when found at the same position
+    func sortedByKeysAndIndexes() -> [Path] {
+        sorted { (lhs, rhs) in
+
+            var lhsIterator = lhs.makeIterator()
+            var rhsIterator = rhs.makeIterator()
+
+            while let lhsElement = lhsIterator.next(), let rhsElement = rhsIterator.next() {
+                switch (lhsElement, rhsElement) {
+
+                case (.key(let lhsLabel), .key(let rhsLabel)):
+                    if lhsLabel != rhsLabel {
+                        return lhsLabel < rhsLabel
+                    }
+
+                case (.index(let lhsIndex), .index(let rhsIndex)):
+                    if lhsIndex != rhsIndex {
+                        return lhsIndex < rhsIndex
+                    }
+
+                default:
+                    return true
+                }
+            }
+
+            return lhs.count < rhs.count // put the shorter path before
+        }
+    }
+}

--- a/Sources/Scout/Models/Path/Path+CompactMapElement.swift
+++ b/Sources/Scout/Models/Path/Path+CompactMapElement.swift
@@ -1,0 +1,49 @@
+//
+// Scout
+// Copyright (c) Alexis Bridoux 2020
+// MIT license, see LICENSE file for details
+
+import Foundation
+
+public extension Path {
+
+    /// Retrieve all the index elements
+    var compactMapIndexes: [Int] {
+        compactMap {
+            if case let .index(index) = $0 {
+                return index
+            }
+            return nil
+        }
+    }
+
+    /// Retrieve all the key elements
+    var compactMapKeys: [String] {
+        compactMap {
+            if case let .key(name) = $0 {
+                return name
+            }
+            return nil
+        }
+    }
+
+    /// Retrieve all the slices bounds elements
+    var compactMapSlices: [Bounds] {
+        compactMap {
+            if case let .slice(bounds) = $0 {
+                return bounds
+            }
+            return nil
+        }
+    }
+
+    /// Retrieve all the filter elements
+    var compactMapFilter: [String] {
+        compactMap {
+            if case let .filter(pattern) = $0 {
+                return pattern
+            }
+            return nil
+        }
+    }
+}

--- a/Sources/Scout/Models/Path/Path+LastKey.swift
+++ b/Sources/Scout/Models/Path/Path+LastKey.swift
@@ -1,0 +1,31 @@
+//
+// Scout
+// Copyright (c) Alexis Bridoux 2020
+// MIT license, see LICENSE file for details
+
+import Foundation
+
+extension Path {
+
+    public var lastKeyElementName: String? {
+        let lastKey = last { (element) -> Bool in
+            if case .key = element { return true }
+            return false
+        }
+        guard case let .key(name) = lastKey else { return nil }
+        return name
+    }
+
+    /// Last key component matching the regular expression
+    public func lastKeyComponent(matches regularExpression: NSRegularExpression) -> Bool {
+        let lastKey = last { (element) -> Bool in
+            if case .key = element {
+                return true
+            }
+            return false
+        }
+        guard case let .key(name) = lastKey else { return false }
+
+        return regularExpression.validate(name)
+    }
+}

--- a/Sources/Scout/Models/Path/Path+StringConvertible.swift
+++ b/Sources/Scout/Models/Path/Path+StringConvertible.swift
@@ -1,0 +1,49 @@
+//
+// Scout
+// Copyright (c) Alexis Bridoux 2020
+// MIT license, see LICENSE file for details
+
+import Foundation
+
+extension Path: CustomStringConvertible, CustomDebugStringConvertible {
+
+    /// Prints all the elements in the path, with the default separator
+    /// #### Complexity
+    /// O(n) with `n` number of elements in the path
+    public var description: String { computeDescription() }
+
+    public var debugDescription: String { description }
+
+    func computeDescription(ignore: ((PathElement) -> Bool)? = nil) -> String {
+        var description = ""
+
+        forEach { element in
+            if let ignore = ignore, ignore(element) { return }
+
+            switch element {
+
+            case .index, .count, .slice, .keysList:
+                // remove the point added automatically to a path element
+                if description.hasSuffix(Self.defaultSeparator) {
+                    description.removeLast()
+                }
+                description.append(element.description)
+
+            case .filter(let pattern):
+                description.append("#\(pattern)#")
+
+            case .key:
+                description.append(element.description)
+            }
+
+            description.append(Self.defaultSeparator)
+        }
+
+        // remove the last point if any
+        if description.hasSuffix(Self.defaultSeparator) {
+            description.removeLast()
+        }
+
+        return description
+    }
+}

--- a/Sources/Scout/Models/Path/Path.swift
+++ b/Sources/Scout/Models/Path/Path.swift
@@ -26,7 +26,7 @@ public struct Path: Hashable {
 
     // MARK: - Properties
 
-    private(set) var elements = [PathElement]()
+    private var elements = [PathElement]()
 
     public static var empty: Path { [] }
 
@@ -77,6 +77,10 @@ public struct Path: Hashable {
         self.elements = elements
     }
 
+    public init() {
+        elements = []
+    }
+
     public init(_ pathElements: [PathElementRepresentable]) {
         elements = pathElements.map(\.pathValue)
     }
@@ -89,16 +93,16 @@ public struct Path: Hashable {
         self.init(Array(pathElements))
     }
 
-    public init(pathElements: PathElement...) {
-        self.init(pathElements)
+    public init(elements: PathElement...) {
+        self.init(elements)
     }
 
-    public init(pathElements: [PathElement]) {
-        self.init(pathElements)
+    public init(elements: [PathElement]) {
+        self.init(elements)
     }
 
-    public init(pathElements: ArraySlice<PathElement>) {
-        self.init(Array(pathElements))
+    public init(elements: ArraySlice<PathElement>) {
+        self.init(Array(elements))
     }
 
     // MARK: - Functions
@@ -113,7 +117,7 @@ public struct Path: Hashable {
 
 // MARK: Collection
 
-extension Path: Collection {
+extension Path: Collection, MutableCollection {
 
     public var startIndex: Int { elements.startIndex }
     public var endIndex: Int { elements.endIndex }
@@ -126,8 +130,15 @@ extension Path: Collection {
     }
 
     public subscript(elementIndex: Int) -> PathElement {
-        assert(elementIndex >= startIndex && elementIndex <= endIndex)
-        return elements[elementIndex]
+        get {
+            assert(elementIndex >= startIndex && elementIndex <= endIndex)
+            return elements[elementIndex]
+        }
+
+        set {
+            assert(elementIndex >= startIndex && elementIndex <= endIndex)
+            elements[elementIndex] = newValue
+        }
     }
 
     public mutating func append(_ element: PathElementRepresentable) {
@@ -136,6 +147,13 @@ extension Path: Collection {
 
     public mutating func popLast() -> PathElement? {
         elements.popLast()
+    }
+}
+
+extension Path: RangeReplaceableCollection {
+
+    public mutating func replaceSubrange<C>(_ subrange: Range<Int>, with newElements: C) where C : Collection, Self.Element == C.Element {
+        elements.replaceSubrange(subrange, with: newElements)
     }
 }
 

--- a/Sources/Scout/Models/PathExplorer/PathExplorer+InternalHelpers.swift
+++ b/Sources/Scout/Models/PathExplorer/PathExplorer+InternalHelpers.swift
@@ -36,7 +36,7 @@ extension PathExplorer {
 public extension PathExplorer {
 
     /// `real` property for convenience naming
-    public var double: Double? { real }
+    var double: Double? { real }
 }
 
 extension PathExplorer {

--- a/Sources/Scout/PathExplorerImplementations/Serialization/PathExplorerSerialization+Add.swift
+++ b/Sources/Scout/PathExplorerImplementations/Serialization/PathExplorerSerialization+Add.swift
@@ -83,7 +83,7 @@ extension PathExplorerSerialization {
     /// Parse the path, adding a key if it does not exist in the dictionay or array
     private func addOrGetKeys(in path: Path) throws -> PathParsingStorage {
         var currentPathExplorer = self
-        var craftingPath = path.elements[0..<path.elements.count - 1]
+        var craftingPath = path[0..<path.count - 1]
         var pathExplorers = [currentPathExplorer]
 
         for (index, element) in craftingPath.enumerated() {

--- a/Tests/ScoutTests/Implementations/Serialization/PathExplorerSerializationTests+Add.swift
+++ b/Tests/ScoutTests/Implementations/Serialization/PathExplorerSerializationTests+Add.swift
@@ -49,7 +49,7 @@ extension PathExplorerSerializationTests {
     func testAddCreateKeyInPath() throws {
         let data = try PropertyListEncoder().encode(StubStruct())
         var plist = try Plist(data: data)
-        let path = Path(pathElements: "animals", "ducks", .count)
+        let path = Path(elements: "animals", "ducks", .count)
 
         try plist.add("Donald", at: path)
 
@@ -60,7 +60,7 @@ extension PathExplorerSerializationTests {
         let array: Any = [["title": "firstTitle"], ["title": "secondTitle"], ["title": "thirdTitle"]]
         let data = try JSONSerialization.data(withJSONObject: array)
         var json = try Json(data: data)
-        let path = Path(pathElements: .count, "title")
+        let path = Path(elements: .count, "title")
 
         try json.add("fourthTitle", at: path)
 
@@ -70,7 +70,7 @@ extension PathExplorerSerializationTests {
     func testAddCreateIndexInEmptyArrayInPath() throws {
         let data = try PropertyListEncoder().encode(StubStruct())
         var plist = try Plist(data: data)
-        let path = Path(pathElements: "animals", "mouses", .count, "name")
+        let path = Path(elements: "animals", "mouses", .count, "name")
 
         try plist.add("Mickey", at: path)
 

--- a/Tests/ScoutTests/Implementations/Serialization/PathExplorerSerializationTests+Delete.swift
+++ b/Tests/ScoutTests/Implementations/Serialization/PathExplorerSerializationTests+Delete.swift
@@ -79,7 +79,7 @@ extension PathExplorerSerializationTests {
     func testDeleteSliceKey() throws {
         let data = try PropertyListEncoder().encode(characters)
         var plist = try Plist(data: data)
-        let path = Path(pathElements: .slice(.init(lower: 0, upper: 1)), .key("name"))
+        let path = Path(elements: .slice(0, 1), "name")
 
         try plist.delete(path)
 
@@ -91,7 +91,7 @@ extension PathExplorerSerializationTests {
     func testDeleteSliceIndex() throws {
         let data = try PropertyListEncoder().encode(characters)
         var plist = try Plist(data: data)
-        let path = Path(pathElements: .slice(.init(lower: 0, upper: 1)), .key("episodes"), .index(0))
+        let path = Path(elements: .slice(0, 1), "episodes", 0)
 
         try plist.delete(path)
 
@@ -103,7 +103,7 @@ extension PathExplorerSerializationTests {
     func testDeleteSliceSlice() throws {
         let data = try PropertyListEncoder().encode(characters)
         var plist = try Plist(data: data)
-        let path = Path(pathElements: .slice(.init(lower: 0, upper: 1)), .key("episodes"), .slice(Bounds(lower: 1, upper: 2)))
+        let path = Path(elements: .slice(0, 1), "episodes", .slice(1, 2))
 
         try plist .delete(path)
 
@@ -115,7 +115,7 @@ extension PathExplorerSerializationTests {
     func testDeleteSliceFilter() throws {
         let data = try PropertyListEncoder().encode(characters)
         var plist = try Plist(data: data)
-        let path = Path(pathElements: .slice(.init(lower: 0, upper: 1)), .filter("episodes|quote"))
+        let path = Path(elements: .slice(0, 1), .filter("episodes|quote"))
 
         try plist .delete(path)
 
@@ -140,7 +140,7 @@ extension PathExplorerSerializationTests {
     func testDeleteArrayStringFilter() throws {
         let data = try PropertyListEncoder().encode(ducks)
         var plist = try Plist(data: data)
-        let path = Path(pathElements: .filter("[A-Z]{1}i[a-z]{1}i"))
+        let path = Path(elements: .filter("[A-Z]{1}i[a-z]{1}i"))
 
         try plist.delete(path)
         let value = plist.value
@@ -202,7 +202,7 @@ extension PathExplorerSerializationTests {
     func testDeleteFilterFilter() throws {
         let data = try PropertyListEncoder().encode(charactersByName)
         var plist = try Plist(data: data)
-        let path = Path(pathElements: .filter("Woody|Buzz"), .filter("episodes|quote"))
+        let path = Path(elements: .filter("Woody|Buzz"), .filter("episodes|quote"))
 
         try plist.delete(path)
 
@@ -242,7 +242,7 @@ extension PathExplorerSerializationTests {
     func testDeleteIfEmptyAfterArraySlice() throws {
         let data = try PropertyListEncoder().encode(characters)
         var plist = try Plist(data: data)
-        let path = Path(pathElements: .slice(Bounds(lower: 0, upper: 1)), .filter(".*"))
+        let path = Path(elements: .slice(0, 1), .filter(".*"))
 
         try plist.delete(path, deleteIfEmpty: true)
 

--- a/Tests/ScoutTests/Implementations/Serialization/PathExplorerSerializationTests+Get.swift
+++ b/Tests/ScoutTests/Implementations/Serialization/PathExplorerSerializationTests+Get.swift
@@ -140,7 +140,7 @@ extension PathExplorerSerializationTests {
     func testGetArraySliceKey() throws {
         let data = try PropertyListEncoder().encode(characters)
         var plist = try Plist(data: data)
-        let path = Path(pathElements: .slice(.init(lower: 0, upper: 1)), .key("name"))
+        let path = Path(elements: .slice(0, 1), "name")
 
         plist = try plist.get(path)
 
@@ -151,7 +151,7 @@ extension PathExplorerSerializationTests {
     func testGetArraySliceIndex() throws {
         let data = try PropertyListEncoder().encode(characters)
         var plist = try Plist(data: data)
-        let path = Path(pathElements: .slice(.init(lower: 0, upper: 1)), .key("episodes"), .index(1))
+        let path = Path(elements: .slice(0, 1), "episodes", 1)
 
         plist = try plist.get(path)
 
@@ -162,7 +162,7 @@ extension PathExplorerSerializationTests {
     func testGetArraySliceCount() throws {
         let data = try PropertyListEncoder().encode(characters)
         var plist = try Plist(data: data)
-        let path = Path(pathElements: .slice(.init(lower: 0, upper: 1)), .key("episodes"), .count)
+        let path = Path(elements: .slice(0, 1), "episodes", .count)
 
         plist = try plist.get(path)
 
@@ -173,7 +173,7 @@ extension PathExplorerSerializationTests {
     func testGetArraySliceArraySlice() throws {
         let data = try PropertyListEncoder().encode(characters)
         var plist = try Plist(data: data)
-        let path = Path(pathElements: .slice(.init(lower: 0, upper: 1)), .key("episodes"), .slice(.init(lower: 1, upper: 2)))
+        let path = Path(elements: .slice(0, 1), "episodes", .slice(1, 2))
 
         plist = try plist.get(path)
 
@@ -184,7 +184,7 @@ extension PathExplorerSerializationTests {
     func testGetArraySliceDictionaryFilter() throws {
         let data = try PropertyListEncoder().encode(charactersByName)
         var plist = try Plist(data: data)
-        let path = Path(pathElements: .filter(".*(z|Z).*"), .key("episodes"), .slice(.init(lower: 1, upper: 2)))
+        let path = Path(elements: .filter(".*(z|Z).*"), "episodes", .slice(1, 2))
 
         plist = try plist.get(path)
 
@@ -245,7 +245,7 @@ extension PathExplorerSerializationTests {
     func testGetDictionaryCount() throws {
         let data = try PropertyListEncoder().encode(charactersByName)
         var plist = try Plist(data: data)
-        let path = Path(pathElements: .filter(".*(z|Z).*"), .count)
+        let path = Path(elements: .filter(".*(z|Z).*"), .count)
 
         plist = try plist.get(path)
 
@@ -256,7 +256,7 @@ extension PathExplorerSerializationTests {
     func testGetDictionaryFilterArraySlice() throws {
         let data = try PropertyListEncoder().encode(characters)
         var plist = try Plist(data: data)
-        let path = Path(pathElements: .slice(.init(lower: 0, upper: 1)), .filter("episodes"))
+        let path = Path(elements: .slice(0, 1), .filter("episodes"))
 
         plist = try plist.get(path)
 
@@ -267,7 +267,7 @@ extension PathExplorerSerializationTests {
     func testGetDictionaryFilterDictionaryFilter() throws {
         let data = try PropertyListEncoder().encode(charactersByName)
         var plist = try Plist(data: data)
-        let path = Path(pathElements: .filter(".*(z|Z).*"), .filter("episodes"))
+        let path = Path(elements: .filter(".*(z|Z).*"), .filter("episodes"))
 
         plist = try plist.get(path)
 

--- a/Tests/ScoutTests/Implementations/XML/PathExplorerXMLTests+Get.swift
+++ b/Tests/ScoutTests/Implementations/XML/PathExplorerXMLTests+Get.swift
@@ -54,7 +54,7 @@ extension PathExplorerXMLTests {
     func testGetArraySlice() throws {
         var xml = try Xml(data: stubData2)
 
-        let path = Path(pathElements: .key("dogs"), .slice(.init(lower: 0, upper: 1)))
+        let path = Path(elements: "dogs", .slice(0, 1))
         xml = try xml.get(path)
 
         let resultValue = xml.element.children.map { $0.string }
@@ -65,7 +65,7 @@ extension PathExplorerXMLTests {
     func testGetArraySliceKey() throws {
         var xml = try Xml(data: toyBox)
 
-        let path = Path(pathElements: .key("toybox"), .key("characters"), .slice(.init(lower: 0, upper: 1)), .key("name"))
+        let path = Path(elements: "toybox", "characters", .slice(0, 1), "name")
         xml = try xml.get(path)
 
         let resultValue = xml.element.children.map { $0.value }

--- a/Tests/ScoutTests/Implementations/XML/PathExplorerXMLTests+Get.swift
+++ b/Tests/ScoutTests/Implementations/XML/PathExplorerXMLTests+Get.swift
@@ -57,7 +57,7 @@ extension PathExplorerXMLTests {
         let path = Path(elements: "dogs", .slice(0, 1))
         xml = try xml.get(path)
 
-        let resultValue = xml.element.children.map { $0.string }
+        let resultValue = xml.element.children.map(\.string)
 
         XCTAssertEqual(["Villy", "Spot"], resultValue)
     }
@@ -68,18 +68,18 @@ extension PathExplorerXMLTests {
         let path = Path(elements: "toybox", "characters", .slice(0, 1), "name")
         xml = try xml.get(path)
 
-        let resultValue = xml.element.children.map { $0.value }
+        let resultValue = xml.element.children.map(\.value)
 
-        XCTAssertEqual(resultValue, Character.toybox[0...1].map { $0.name })
+        XCTAssertEqual(resultValue, Character.toybox[0...1].map(\.name))
     }
 
     func testGetArraySliceIndex() throws {
         var xml = try Xml(data: toyBox)
 
-        let path = Path(pathElements: .key("toybox"), .key("characters"), .slice(.init(lower: 0, upper: 1)), .key("episodes"), .index(0))
+        let path = Path(elements: "toybox", "characters", .slice(0, 1), "episodes", 0)
         xml = try xml.get(path)
 
-        let resultValue = xml.element.children.map { $0.int }
+        let resultValue = xml.element.children.map(\.int)
 
         XCTAssertEqual(resultValue, [1, 1])
     }
@@ -87,9 +87,9 @@ extension PathExplorerXMLTests {
     func testGetSliceCount() throws {
         var xml = try Xml(data: toyBox)
 
-        xml = try xml.get(["toybox", "characters", PathElement.slice(.init(lower: 0, upper: 1)), "episodes", PathElement.count])
+        xml = try xml.get("toybox", "characters", .slice(0, 1), "episodes", .count)
 
-        let resultValue = xml.element.children.map { $0.int }
+        let resultValue = xml.element.children.map(\.int)
 
         XCTAssertEqual(resultValue, [3, 3])
     }
@@ -97,9 +97,9 @@ extension PathExplorerXMLTests {
     func testGetSliceGroupSample() throws {
         var xml = try Xml(data: toyBox)
 
-        xml = try xml.get(["toybox", "characters", PathElement.slice(.init(lower: 0, upper: 1)), "episodes", PathElement.slice(Bounds(lower: 0, upper: 1))])
+        xml = try xml.get("toybox", "characters", .slice(0, 1), "episodes", .slice( 0, 1))
 
-        let resultValue = xml.element.children.flatMap { $0.children }.map { $0.int }
+        let resultValue = xml.element.children.flatMap(\.children).map(\.int)
 
         XCTAssertEqual(resultValue, [1, 2, 1, 2])
     }


### PR DESCRIPTION
Closes #171 

- Changed `Path` initialisations. Removed now useless ArraySlice<PathElement> inits and changed `init(pathsElements:)` to `init(elements:)`.