### PR TITLE
Made Path implement RandomAccessCollection

### DIFF
--- a/Sources/Scout/Extensions/String+Extension.swift
+++ b/Sources/Scout/Extensions/String+Extension.swift
@@ -28,6 +28,14 @@ extension String {
         return hasPrefix(string) && hasSuffix(string)
     }
 
+    /// Remove the enclosing brackets '(' ')' if found
+    func removingEnclosingBrackets() -> String {
+        if hasPrefix("("), hasSuffix(")") {
+            return String(self[index(after: startIndex)..<index(before: endIndex)])
+        }
+        return self
+    }
+
     /// Escape the given string for a CSV export
     func escapingCSV(_ string: String) -> String {
         if contains(string) {

--- a/Sources/Scout/Models/Path/Bounds.swift
+++ b/Sources/Scout/Models/Path/Bounds.swift
@@ -23,11 +23,11 @@ public struct Bounds: Hashable {
     private(set) var lastComputedUpper
 
     /// Description of the lower bound.
-    /// - note: Do not use this value to convert it to an Int. Rather use the `range(lastValidIndex:path)` function to access to the lower bound
+    /// - note: Do not use this value to convert it to an Int. Rather use the `range(arrayCount:path)` function to access to the lower bound
     var lowerString: String { lower == .first ? "" : String(lower.value) }
 
     /// Description of the upper bound.
-    /// - note: Do not use this value to convert it to an Int. Rather use the `range(lastValidIndex:path)` function to access to the upper bound
+    /// - note: Do not use this value to convert it to an Int. Rather use the `range(arrayCount:path)` function to access to the upper bound
     var upperString: String { upper == .last ? "" : String(upper.value) }
 
     // MARK: - Initialization
@@ -40,7 +40,7 @@ public struct Bounds: Hashable {
     // MARK: - Functions
 
     /// - Parameters:
-    ///   - arrayCount:The count of the array
+    ///   - arrayCount: The count of the array to slice
     ///   - path: Path where the bounds is specified. Used to throw a relevant error
     /// - Throws: If the bounds are invalid
     /// - Returns: A range made from the lower and upper bounds

--- a/Sources/ScoutCLT/Extensions/Path+Extensions.swift
+++ b/Sources/ScoutCLT/Extensions/Path+Extensions.swift
@@ -12,7 +12,7 @@ extension Path: ExpressibleByArgument {
     // MARK: - Initialization
 
     public init?(argument: String) {
-        try? self.init(string: argument)
+        self.init(string: argument)
     }
 
     // MARK: - Functions
@@ -56,11 +56,9 @@ extension Path: ExpressibleByArgument {
             argument.removeFirst()
         }
 
-        do {
-            let path = try Path(string: argument)
-            let newArgument = complete(path: path, in: data, with: pathExplorer)
-            argumentsCopy[arguments.count - 1] = newArgument
-        } catch {}
+        let path = Path(string: argument)
+        let newArgument = complete(path: path, in: data, with: pathExplorer)
+        argumentsCopy[arguments.count - 1] = newArgument
 
         return argumentsCopy
     }

--- a/Tests/ScoutTests/Definitions/PathTests+Extensions.swift
+++ b/Tests/ScoutTests/Definitions/PathTests+Extensions.swift
@@ -80,7 +80,7 @@ final class PathExtensionsTests: XCTestCase {
     }
 
     func testFlatten(_ description: String, expected: String) throws {
-        let path = try Path(string: description)
+        let path = Path(string: description)
 
         try path.forEach {
             if case let .slice(bounds) = $0 {
@@ -94,17 +94,17 @@ final class PathExtensionsTests: XCTestCase {
     // MARK: Sorted key and indexes
 
     func testSortedKeysAndIndexes1() throws {
-        let path1 = try Path(string: "movies[2].chapters[4]")
-        let path2 = try Path(string: "movies[3].chapters[3]")
-        let path3 = try Path(string: "movies[3].chapters[4]")
+        let path1 = Path(string: "movies[2].chapters[4]")
+        let path2 = Path(string: "movies[3].chapters[3]")
+        let path3 = Path(string: "movies[3].chapters[4]")
 
         XCTAssertEqual([path2, path3, path1].sortedByKeysAndIndexes(), [path1, path2, path3])
     }
 
     func testSortedKeysAndIndexes2() throws {
-        let path1 = try Path(string: "actors.prices")
-        let path2 = try Path(string: "movies[3].chapters[3]")
-        let path3 = try Path(string: "movies[4].chapters[2]")
+        let path1 = Path(string: "actors.prices")
+        let path2 = Path(string: "movies[3].chapters[3]")
+        let path3 = Path(string: "movies[4].chapters[2]")
 
         XCTAssertEqual([path2, path3, path1].sortedByKeysAndIndexes(), [path1, path2, path3])
     }

--- a/Tests/ScoutTests/Definitions/PathTests.swift
+++ b/Tests/ScoutTests/Definitions/PathTests.swift
@@ -47,91 +47,91 @@ final class PathTests: XCTestCase {
 
     func testSimpleKeys() throws {
         let array: Path = [firstKey, secondKey, thirdKey]
-        let path = try Path(string: "\(firstKey).\(secondKey).\(thirdKey)")
+        let path = Path(string: "\(firstKey).\(secondKey).\(thirdKey)")
 
         XCTAssertEqual(path, array)
     }
 
     func testKeysWithIndex() throws {
         let array: Path = [firstKey, secondKey, index, thirdKey]
-        let path = try Path(string: "\(firstKey).\(secondKeyWithIndex).\(thirdKey)")
+        let path = Path(string: "\(firstKey).\(secondKeyWithIndex).\(thirdKey)")
 
         XCTAssertEqual(path, array)
     }
 
     func testKeysWithNegativeIndex() throws {
         let array: Path = [firstKey, secondKey, -index, thirdKey]
-        let path = try Path(string: "\(firstKey).\(secondKeyWithNegativeIndex).\(thirdKey)")
+        let path = Path(string: "\(firstKey).\(secondKeyWithNegativeIndex).\(thirdKey)")
 
         XCTAssertEqual(path, array)
     }
 
     func testKeysWithBrackets() throws {
         let array: Path = [firstKey, secondKey, index, thirdKeyWithDot]
-        let path = try Path(string: "\(firstKey).\(secondKeyWithIndex).(\(thirdKeyWithDot))")
+        let path = Path(string: "\(firstKey).\(secondKeyWithIndex).(\(thirdKeyWithDot))")
 
         XCTAssertEqual(path, array)
     }
 
     func testKeysWithBracketsAndIndex() throws {
         let array: Path = [firstKey, secondKeyWithDot, 1, thirdKey]
-        let path = try Path(string: "\(firstKey).(\(secondKeyWithDot))[1]\(thirdKey)")
+        let path = Path(string: "\(firstKey).(\(secondKeyWithDot))[1]\(thirdKey)")
 
         XCTAssertEqual(path, array)
     }
 
     func testNestedArray() throws {
         let array: Path = [firstKey, secondKey, index, 0, thirdKey]
-        let path = try Path(string: "\(firstKey).\(secondKeyWithNestedArray).\(thirdKey)")
+        let path = Path(string: "\(firstKey).\(secondKeyWithNestedArray).\(thirdKey)")
 
         XCTAssertEqual(path, array)
     }
 
     func testNestedArrayTwoLevels() throws {
         let array: Path = [firstKey, secondKey, index, 0, 2, thirdKey]
-        let path = try Path(string: "\(firstKey).\(secondKeyWithTwoNestedArrays).\(thirdKey)")
+        let path = Path(string: "\(firstKey).\(secondKeyWithTwoNestedArrays).\(thirdKey)")
 
         XCTAssertEqual(path, array)
     }
 
     func testSeparator1() throws {
         let array: Path = [firstKey, secondKey, thirdKey]
-        let path = try Path(string: "\(firstKey)\(secondSeparator)\(secondKey)\(secondSeparator)\(thirdKey)", separator: secondSeparator)
+        let path = Path(string: "\(firstKey)\(secondSeparator)\(secondKey)\(secondSeparator)\(thirdKey)", separator: secondSeparator)
 
         XCTAssertEqual(path, array)
     }
 
     func testSeparator2() throws {
         let array: Path = [firstKey, secondKey, thirdKey]
-        let path = try Path(string: "\(firstKey)\(thirdSeparator)\(secondKey)\(thirdSeparator)\(thirdKey)", separator: thirdSeparator)
+        let path = Path(string: "\(firstKey)\(thirdSeparator)\(secondKey)\(thirdSeparator)\(thirdKey)", separator: thirdSeparator)
 
         XCTAssertEqual(path, array)
     }
 
     func testSeparator3() throws {
         let array: Path = [firstKey, secondKey, thirdKey]
-        let path = try Path(string: "\(firstKey)$\(secondKey)$\(thirdKey)", separator: fourthSeparator)
+        let path = Path(string: "\(firstKey)$\(secondKey)$\(thirdKey)", separator: fourthSeparator)
 
         XCTAssertEqual(path, array)
     }
 
     func testSeparator3WithBracketAndIndex() throws {
         let array: Path = [firstKey, secondKeyWithFourthSeparator, index, thirdKey]
-        let path = try Path(string: "\(firstKey)$(\(secondKeyWithFourthSeparator))[\(index)]$\(thirdKey)", separator: fourthSeparator)
+        let path = Path(string: "\(firstKey)$(\(secondKeyWithFourthSeparator))[\(index)]$\(thirdKey)", separator: fourthSeparator)
 
         XCTAssertEqual(path, array)
     }
 
     func testRootElementArray() throws {
         let array: Path = [1, firstKey, secondKey]
-        let path = try Path(string: "[1].\(firstKey).\(secondKey)")
+        let path = Path(string: "[1].\(firstKey).\(secondKey)")
 
         XCTAssertEqual(path, array)
     }
 
     func testRootElementNestedArrays() throws {
         let array: Path = [1, 0, firstKey, secondKey]
-        let path = try Path(string: "[1][0].\(firstKey).\(secondKey)")
+        let path = Path(string: "[1][0].\(firstKey).\(secondKey)")
 
         XCTAssertEqual(path, array)
     }
@@ -140,14 +140,14 @@ final class PathTests: XCTestCase {
 
     func testCount() throws {
         let array: Path = [secondKey, PathElement.count]
-        let path = try Path(string: secondKeyWithCount)
+        let path = Path(string: secondKeyWithCount)
 
         XCTAssertEqual(path, array)
     }
 
     func testCountNotFinal() throws {
         let array: Path = [thirdKey, PathElement.count, secondKey]
-        let path = try Path(string: thirdKeyWithCount)
+        let path = Path(string: thirdKeyWithCount)
 
         XCTAssertEqual(path, array)
     }
@@ -156,21 +156,21 @@ final class PathTests: XCTestCase {
 
     func testKeysList() throws {
         let array: Path = [secondKey, PathElement.keysList]
-        let path = try Path(string: secondKeyWithKeysList)
+        let path = Path(string: secondKeyWithKeysList)
 
         XCTAssertEqual(path, array)
     }
 
     func testKeysListFirstElement() throws {
         let array: Path = [PathElement.keysList, 1]
-        let path = try Path(string: "{#}[1]")
+        let path = Path(string: "{#}[1]")
 
         XCTAssertEqual(path, array)
     }
 
     func testKeysListAfterIndex() throws {
         let array: Path = ["hello", 1, PathElement.keysList]
-        let path = try Path(string: "hello[1]{#}")
+        let path = Path(string: "hello[1]{#}")
 
         XCTAssertEqual(path, array)
     }
@@ -179,21 +179,21 @@ final class PathTests: XCTestCase {
 
     func testFullSlice() throws {
         let array = Path(secondKey, PathElement.slice(2, 4))
-        let path = try Path(string: secondKeyWithFullRange)
+        let path = Path(string: secondKeyWithFullRange)
 
         XCTAssertEqual(path, array)
     }
 
     func testPartialSliceLeft() throws {
         let array = Path(secondKey, PathElement.slice(.init(lower: .first, upper: 4)))
-        let path = try Path(string: secondKeyWithPartialRangeLeft)
+        let path = Path(string: secondKeyWithPartialRangeLeft)
 
         XCTAssertEqual(path, array)
     }
 
     func testPartialSliceRight() throws {
         let array = Path(secondKey, PathElement.slice(1, .last))
-        let path = try Path(string: secondKeyWithPartialRangeRight)
+        let path = Path(string: secondKeyWithPartialRangeRight)
 
         XCTAssertEqual(path, array)
     }
@@ -202,14 +202,14 @@ final class PathTests: XCTestCase {
 
     func testFilter() throws {
         let array = Path(secondKey, PathElement.filter("Halo.*"))
-        let path = try Path(string: secondKeyWithFilter)
+        let path = Path(string: secondKeyWithFilter)
 
         XCTAssertEqual(path, array)
     }
 
     func testFilterAndCount() throws {
         let array = Path(secondKey, PathElement.filter("Halo.*"), PathElement.count)
-        let path = try Path(string: secondKeyWithFilterAndCount)
+        let path = Path(string: secondKeyWithFilterAndCount)
 
         XCTAssertEqual(path, array)
     }


### PR DESCRIPTION
- `Path(string:separator:)` does not throw anymore but exit with a precondition failure if the regex is invalid
- Small comments oversights fixed
Closes #171 