### PR TITLE
Reading from standard input fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file. `Scout` adheres to [Semantic Versioning](http://semver.org).
 
 ---
+## [3.0.2](https://github.com/ABridoux/scout/tree/3.0.2) (22/03/2021)
+### Fixed
+- Reading from standard input [#
+
 ## [3.0.1](https://github.com/ABridoux/scout/tree/3.0.1) (06/03/2021)
 
 ### Added

--- a/Sources/Scout/Constants/ScoutVersion.swift
+++ b/Sources/Scout/Constants/ScoutVersion.swift
@@ -4,5 +4,5 @@
 // MIT license, see LICENSE file for details
 
 public enum ScoutVersion {
-    public static let current = "3.0.1"
+    public static let current = "3.0.2"
 }


### PR DESCRIPTION
The property `FileHandle.standardInput.availableData` was not retrieving all the available data when the size was too large (I misread the documentation).
The proper function is now used with an os version condition.

Closes #192 