### PR TITLE
Feature/clt new explorers

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/ScoutCLT.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/ScoutCLT.xcscheme
@@ -99,12 +99,6 @@
             ReferencedContainer = "container:">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-         <CommandLineArgument
-            argument = "read -i /Users/alexisbridoux/Documents/Xcode/Scout/Playground/People.xml"
-            isEnabled = "YES">
-         </CommandLineArgument>
-      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/.swiftpm/xcode/xcshareddata/xcschemes/ScoutCLT.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/ScoutCLT.xcscheme
@@ -82,6 +82,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableAddressSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -98,6 +99,12 @@
             ReferencedContainer = "container:">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "read -i /Users/alexisbridoux/Documents/Xcode/Scout/Playground/People.xml"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/.swiftpm/xcode/xcshareddata/xcschemes/ScoutCLT.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/ScoutCLT.xcscheme
@@ -82,7 +82,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      enableAddressSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Package.resolved
+++ b/Package.resolved
@@ -56,12 +56,12 @@
         }
       },
       {
-        "package": "XMLParsing",
-        "repositoryURL": "https://github.com/ShawnMoore/XMLParsing",
+        "package": "XMLCoder",
+        "repositoryURL": "https://github.com/MaxDesiatov/XMLCoder",
         "state": {
           "branch": null,
-          "revision": "2b77a8078d9695aac1a0e5806768e819025174c3",
-          "version": "0.0.3"
+          "revision": "b8fa7fe4c0849f8a64cc246e71c5d976809222e4",
+          "version": "0.12.0"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/ABridoux/BooleanExpressionEvaluation",
         "state": {
           "branch": null,
-          "revision": "ab25774a0368e12def337fa941a41a6be2757fd1",
-          "version": "2.0.0"
+          "revision": "0af945fffa42447e455620ccaaa26d80528e3884",
+          "version": "2.0.1"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "9564d61b08a5335ae0a36f789a7d71493eacadfc",
-          "version": "0.3.2"
+          "revision": "831ed5e860a70e745bc1337830af4786b2576881",
+          "version": "0.4.1"
         }
       },
       {
@@ -56,12 +56,12 @@
         }
       },
       {
-        "package": "XMLCoder",
-        "repositoryURL": "https://github.com/MaxDesiatov/XMLCoder",
+        "package": "XMLParsing",
+        "repositoryURL": "https://github.com/ShawnMoore/XMLParsing",
         "state": {
           "branch": null,
-          "revision": "b8fa7fe4c0849f8a64cc246e71c5d976809222e4",
-          "version": "0.12.0"
+          "revision": "2b77a8078d9695aac1a0e5806768e819025174c3",
+          "version": "0.0.3"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "9003d51672e516cc59297b7e96bff1dfdedcb4ea",
-          "version": "4.0.4"
+          "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
+          "version": "4.0.6"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -22,8 +22,8 @@ let package = Package(
             url: "https://github.com/tadija/AEXML.git",
             from: "4.5.0"),
         .package(
-            url: "https://github.com/MaxDesiatov/XMLCoder",
-            from: "0.1.0"),
+            url: "https://github.com/ShawnMoore/XMLParsing",
+            from: "0.0.3"),
         .package(
             url: "https://github.com/apple/swift-argument-parser",
             from: "0.0.1"),
@@ -43,7 +43,7 @@ let package = Package(
             name: "Scout",
             dependencies: [
                 "AEXML",
-                "XMLCoder",
+                "XMLParsing",
                 "Yams",
                 "BooleanExpressionEvaluation"]),
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -22,8 +22,8 @@ let package = Package(
             url: "https://github.com/tadija/AEXML.git",
             from: "4.5.0"),
         .package(
-            url: "https://github.com/ShawnMoore/XMLParsing",
-            from: "0.0.3"),
+            url: "https://github.com/MaxDesiatov/XMLCoder",
+            from: "0.12.0"),
         .package(
             url: "https://github.com/apple/swift-argument-parser",
             from: "0.0.1"),
@@ -43,7 +43,7 @@ let package = Package(
             name: "Scout",
             dependencies: [
                 "AEXML",
-                "XMLParsing",
+                "XMLCoder",
                 "Yams",
                 "BooleanExpressionEvaluation"]),
         .target(

--- a/Playground/People.xml
+++ b/Playground/People.xml
@@ -1,41 +1,51 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<People>
+<people>
     <Tom>
-        <age>68</age>
-        <hobbies>cooking</hobbies>
-        <hobbies>guitar</hobbies>
         <height>175</height>
+        <age>68</age>
+        <hobbies>
+            <hobby>cooking</hobby>
+            <hobby>guitar</hobby>
+        </hobbies>
     </Tom>
+
+    <Robert>
+        <height>181</height>
+        <age>23</age>
+        <hobbies>
+            <hobby>video games</hobby>
+            <hobby>party</hobby>
+            <hobby>tennis</hobby>
+        </hobbies>
+        <running_records>
+            <records>
+                <record>10</record>
+                <record>12</record>
+                <record>9</record>
+                <record>10</record>
+            </records>
+            <records>
+                <record>9</record>
+                <record>12</record>
+                <record>11</record>
+            </records>
+        </running_records>
+    </Robert>
+
     <Suzanne>
         <job>actress</job>
         <movies>
-            <title>Tomorrow is so far</title>
-            <awards>Best speech for a silent movie</awards>
-        </movies>
-        <movies>
-            <title>Yesterday will never go</title>
-            <awards>Best title</awards>
-        </movies>
-        <movies>
-            <title>What about today?</title>
+            <movie>
+                <title>Tomorrow is so far</title>
+                <awards>Best speech for a silent movie</awards>
+            </movie>
+            <movie>
+                <title>Yesterday will never go</title>
+                <awards>Best title</awards>
+            </movie>
+            <movie>
+                <title>What about today?</title>
+            </movie>
         </movies>
     </Suzanne>
-    <Robert>
-        <running_records>
-            <running_records>10</running_records>
-            <running_records>12</running_records>
-            <running_records>9</running_records>
-            <running_records>10</running_records>
-        </running_records>
-        <running_records>
-            <running_records>9</running_records>
-            <running_records>12</running_records>
-            <running_records>11</running_records>
-        </running_records>
-        <hobbies>video games</hobbies>
-        <hobbies>party</hobbies>
-        <hobbies>tennis</hobbies>
-        <height>181</height>
-        <age>23</age>
-    </Robert>
-</People>
+</people>

--- a/Playground/People.xml
+++ b/Playground/People.xml
@@ -1,51 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<people>
-	<Tom>
-		<height>175</height>
-		<age>68</age>
-		<hobbies>
-			<hobby>cooking</hobby>
-			<hobby>guitar</hobby>
-		</hobbies>
-	</Tom>
-
-	<Robert>
-		<height>181</height>
-		<age>23</age>
-		<hobbies>
-			<hobby>video games</hobby>
-			<hobby>party</hobby>
-			<hobby>tennis</hobby>
-		</hobbies>
-		<running_records>
-			<records>
-				<record>10</record>
-				<record>12</record>
-				<record>9</record>
-				<record>10</record>
-			</records>
-			<records>
-				<record>9</record>
-				<record>12</record>
-				<record>11</record>
-			</records>
-		</running_records>
-	</Robert>
-
-	<Suzanne>
-		<job>actress</job>
-		<movies>
-			<movie>
-				<title>Tomorrow is so far</title>
-				<awards>Best speech for a silent movie</awards>
-			</movie>
-			<movie>
-				<title>Yesterday will never go</title>
-				<awards>Best title</awards>
-			</movie>
-			<movie>
-				<title>What about today?</title>
-			</movie>
-		</movies>
-	</Suzanne>
-</people>
+<People>
+    <Tom>
+        <age>68</age>
+        <hobbies>cooking</hobbies>
+        <hobbies>guitar</hobbies>
+        <height>175</height>
+    </Tom>
+    <Suzanne>
+        <job>actress</job>
+        <movies>
+            <title>Tomorrow is so far</title>
+            <awards>Best speech for a silent movie</awards>
+        </movies>
+        <movies>
+            <title>Yesterday will never go</title>
+            <awards>Best title</awards>
+        </movies>
+        <movies>
+            <title>What about today?</title>
+        </movies>
+    </Suzanne>
+    <Robert>
+        <running_records>
+            <running_records>10</running_records>
+            <running_records>12</running_records>
+            <running_records>9</running_records>
+            <running_records>10</running_records>
+        </running_records>
+        <running_records>
+            <running_records>9</running_records>
+            <running_records>12</running_records>
+            <running_records>11</running_records>
+        </running_records>
+        <hobbies>video games</hobbies>
+        <hobbies>party</hobbies>
+        <hobbies>tennis</hobbies>
+        <height>181</height>
+        <age>23</age>
+    </Robert>
+</People>

--- a/Sources/Scout/ExplorerValueSerialization/CodableFormat.swift
+++ b/Sources/Scout/ExplorerValueSerialization/CodableFormat.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 import Yams
-import XMLCoder
+import XMLParsing
 
 public protocol CodableFormat {
 
@@ -66,13 +66,13 @@ public extension CodableFormats {
             + #"|(?<=<dict>)\s*<key>\#(foldedKey)</key>\s*<string>\#(foldedMark)</string>\s*(?=</dict>)"# // dict
         }
 
-        public static func encode<E>(_ value: E, rootName: String?) throws -> Data where E : Encodable {
+        public static func encode<E>(_ value: E, rootName: String?) throws -> Data where E: Encodable {
             let encoder = PropertyListEncoder()
             encoder.outputFormat = .xml
             return try encoder.encode(value)
         }
 
-        public static func decode<D>(_ type: D.Type, from data: Data) throws -> D where D : Decodable {
+        public static func decode<D>(_ type: D.Type, from data: Data) throws -> D where D: Decodable {
             try PropertyListDecoder().decode(type, from: data)
         }
     }
@@ -89,11 +89,11 @@ public extension CodableFormats {
             + #"|\#(foldedKey)\s*:\s*\#(foldedMark)\s*(?=\n)"# // dict
         }
 
-        public static func encode<E>(_ value: E, rootName: String?) throws -> Data where E : Encodable {
+        public static func encode<E>(_ value: E, rootName: String?) throws -> Data where E: Encodable {
             try YAMLEncoder().encode(value).data(using: .utf8).unwrapOrThrow(.stringToData)
         }
 
-        public static func decode<D>(_ type: D.Type, from data: Data) throws -> D where D : Decodable {
+        public static func decode<D>(_ type: D.Type, from data: Data) throws -> D where D: Decodable {
             try YAMLDecoder().decode(type, from: data)
         }
     }
@@ -106,13 +106,13 @@ public extension CodableFormats {
         public static var dataFormat: DataFormat { .xml }
         public static let foldedRegexPattern = #"(?<=>)\s*<\#(foldedKey)>\#(foldedMark)</\#(foldedKey)>\s*(?=<)"#
 
-        public static func encode<E>(_ value: E, rootName: String?) throws -> Data where E : Encodable {
+        public static func encode<E>(_ value: E, rootName: String?) throws -> Data where E: Encodable {
             let encoder = XMLEncoder()
             encoder.outputFormatting = .prettyPrinted
-            return try encoder.encode(value, withRootKey: rootName)
+            return try encoder.encode(value, withRootKey: rootName ?? "root")
         }
 
-        public static func decode<D>(_ type: D.Type, from data: Data) throws -> D where D : Decodable {
+        public static func decode<D>(_ type: D.Type, from data: Data) throws -> D where D: Decodable {
             try XMLDecoder().decode(type, from: data)
         }
     }

--- a/Sources/Scout/ExplorerValueSerialization/CodableFormat.swift
+++ b/Sources/Scout/ExplorerValueSerialization/CodableFormat.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 import Yams
-import XMLParsing
+import XMLCoder
 
 public protocol CodableFormat {
 

--- a/Sources/Scout/ExplorerValueSerialization/CodableFormat.swift
+++ b/Sources/Scout/ExplorerValueSerialization/CodableFormat.swift
@@ -14,8 +14,15 @@ public protocol CodableFormat {
     /// Regex used to find folded marks in the description of a folded explorer
     static var foldedRegexPattern: String { get }
 
-    static func encode<E: Encodable>(_ value: E) throws -> Data
+    static func encode<E: Encodable>(_ value: E, rootName: String?) throws -> Data
     static func decode<D: Decodable>(_ type: D.Type, from data: Data) throws -> D
+}
+
+public extension CodableFormat {
+
+    static func encode<E: Encodable>(_ value: E) throws -> Data {
+        try encode(value, rootName: nil)
+    }
 }
 
 private extension CodableFormat {
@@ -36,8 +43,10 @@ public extension CodableFormats {
             + #"|(?<=\{)\s*"\#(foldedKey)"\s*:\s*"\#(foldedMark)"\s*(?=\})"# // dict
         }
 
-        public static func encode<E: Encodable>(_ value: E) throws -> Data {
-            try JSONEncoder().encode(value)
+        public static func encode<E: Encodable>(_ value: E, rootName: String?) throws -> Data {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = .prettyPrinted
+            return try encoder.encode(value)
         }
 
         public static func decode<D>(_ type: D.Type, from data: Data) throws -> D where D: Decodable {
@@ -57,8 +66,10 @@ public extension CodableFormats {
             + #"|(?<=<dict>)\s*<key>\#(foldedKey)</key>\s*<string>\#(foldedMark)</string>\s*(?=</dict>)"# // dict
         }
 
-        public static func encode<E>(_ value: E) throws -> Data where E : Encodable {
-            try PropertyListEncoder().encode(value)
+        public static func encode<E>(_ value: E, rootName: String?) throws -> Data where E : Encodable {
+            let encoder = PropertyListEncoder()
+            encoder.outputFormat = .xml
+            return try encoder.encode(value)
         }
 
         public static func decode<D>(_ type: D.Type, from data: Data) throws -> D where D : Decodable {
@@ -78,7 +89,7 @@ public extension CodableFormats {
             + #"|\#(foldedKey)\s*:\s*\#(foldedMark)\s*(?=\n)"# // dict
         }
 
-        public static func encode<E>(_ value: E) throws -> Data where E : Encodable {
+        public static func encode<E>(_ value: E, rootName: String?) throws -> Data where E : Encodable {
             try YAMLEncoder().encode(value).data(using: .utf8).unwrapOrThrow(.stringToData)
         }
 
@@ -95,8 +106,10 @@ public extension CodableFormats {
         public static var dataFormat: DataFormat { .xml }
         public static let foldedRegexPattern = #"(?<=>)\s*<\#(foldedKey)>\#(foldedMark)</\#(foldedKey)>\s*(?=<)"#
 
-        public static func encode<E>(_ value: E) throws -> Data where E : Encodable {
-            try XMLEncoder().encode(value)
+        public static func encode<E>(_ value: E, rootName: String?) throws -> Data where E : Encodable {
+            let encoder = XMLEncoder()
+            encoder.outputFormatting = .prettyPrinted
+            return try encoder.encode(value, withRootKey: rootName)
         }
 
         public static func decode<D>(_ type: D.Type, from data: Data) throws -> D where D : Decodable {

--- a/Sources/Scout/ExplorerValueSerialization/ExplorerValueConvertible+Codable/Decoding/ExplorerValueDecoder.swift
+++ b/Sources/Scout/ExplorerValueSerialization/ExplorerValueConvertible+Codable/Decoding/ExplorerValueDecoder.swift
@@ -7,7 +7,7 @@ import Foundation
 
 final class ExplorerValueDecoder: Decoder {
     var codingPath: [CodingKey]
-    var userInfo: [CodingUserInfoKey : Any] = [:]
+    var userInfo: [CodingUserInfoKey: Any] = [:]
     let value: ExplorerValue
 
     init(_ value: ExplorerValue, codingPath: [CodingKey] = []) {
@@ -15,7 +15,7 @@ final class ExplorerValueDecoder: Decoder {
         self.codingPath = codingPath
     }
 
-    func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> where Key : CodingKey {
+    func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> where Key: CodingKey {
         KeyedDecodingContainer(Container(value: value, codingPath: codingPath, decoder: self))
     }
 

--- a/Sources/Scout/ExplorerValueSerialization/ExplorerValueConvertible+Codable/Decoding/ExplorerValueDecodingContainer.swift
+++ b/Sources/Scout/ExplorerValueSerialization/ExplorerValueConvertible+Codable/Decoding/ExplorerValueDecodingContainer.swift
@@ -17,7 +17,7 @@ extension ExplorerValueDecoder {
             self.value = value
             self.codingPath = codingPath
             self.decoder = decoder
-            
+
             if case let .keysList(keys) = try? value.get(.keysList) {
                 allKeys = keys.compactMap(Key.init)
             }
@@ -126,7 +126,7 @@ extension ExplorerValueDecoder {
                 .unwrapOrThrow(.typeMismatch(Data.self, codingPath: codingPath + [key]))
         }
 
-        func decode<T>(_ type: T.Type, forKey key: Key) throws -> T where T : Decodable {
+        func decode<T>(_ type: T.Type, forKey key: Key) throws -> T where T: Decodable {
             let value = try valueFor(key: key)
 
             if T.self == Data.self {
@@ -137,7 +137,7 @@ extension ExplorerValueDecoder {
             return try T(from: decoder)
         }
 
-        func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: Key) throws -> KeyedDecodingContainer<NestedKey> where NestedKey : CodingKey {
+        func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: Key) throws -> KeyedDecodingContainer<NestedKey> where NestedKey: CodingKey {
             let value = try valueFor(key: key)
             return KeyedDecodingContainer(Container<NestedKey>(value: value, codingPath: codingPath + [key], decoder: decoder))
         }

--- a/Sources/Scout/ExplorerValueSerialization/ExplorerValueConvertible+Codable/Decoding/ExplorerValueSingleDecodingContainer.swift
+++ b/Sources/Scout/ExplorerValueSerialization/ExplorerValueConvertible+Codable/Decoding/ExplorerValueSingleDecodingContainer.swift
@@ -74,7 +74,7 @@ extension ExplorerValueDecoder {
             try value.data.unwrapOrThrow(.typeMismatch(Data.self, codingPath: codingPath))
         }
 
-        func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
+        func decode<T>(_ type: T.Type) throws -> T where T: Decodable {
             if T.self == Data.self {
                 return try decode(Data.self) as! T
             }

--- a/Sources/Scout/ExplorerValueSerialization/ExplorerValueConvertible+Codable/Decoding/ExplorerValueUnkeyedDecodingContainer.swift
+++ b/Sources/Scout/ExplorerValueSerialization/ExplorerValueConvertible+Codable/Decoding/ExplorerValueUnkeyedDecodingContainer.swift
@@ -107,7 +107,7 @@ extension ExplorerValueDecoder {
             return value
         }
 
-        mutating func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
+        mutating func decode<T>(_ type: T.Type) throws -> T where T: Decodable {
             if T.self == Data.self {
                 return try decode(Data.self) as! T
             }
@@ -118,7 +118,7 @@ extension ExplorerValueDecoder {
             return decoded
         }
 
-        mutating func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type) throws -> KeyedDecodingContainer<NestedKey> where NestedKey : CodingKey {
+        mutating func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type) throws -> KeyedDecodingContainer<NestedKey> where NestedKey: CodingKey {
             let value = array[currentIndex]
             return KeyedDecodingContainer(Container<NestedKey>(value: value, codingPath: codingPath, decoder: decoder))
         }

--- a/Sources/Scout/ExplorerValueSerialization/ExplorerValueConvertible+Codable/Encoding/ExplorerValueEncoder.swift
+++ b/Sources/Scout/ExplorerValueSerialization/ExplorerValueConvertible+Codable/Encoding/ExplorerValueEncoder.swift
@@ -7,14 +7,14 @@ import Foundation
 
 final class ExplorerValueEncoder: Encoder {
     var codingPath: [CodingKey]
-    var userInfo: [CodingUserInfoKey : Any] = [:]
+    var userInfo: [CodingUserInfoKey: Any] = [:]
     var value: ExplorerValue!
 
     init(codingPath: [CodingKey] = []) {
         self.codingPath = codingPath
     }
 
-    func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key : CodingKey {
+    func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key: CodingKey {
         value = .dictionary([:])
         return KeyedEncodingContainer(Container(codingPath: codingPath, encoder: self, path: .empty))
     }

--- a/Sources/Scout/ExplorerValueSerialization/ExplorerValueConvertible+Codable/Encoding/ExplorerValueEncodingContainer.swift
+++ b/Sources/Scout/ExplorerValueSerialization/ExplorerValueConvertible+Codable/Encoding/ExplorerValueEncodingContainer.swift
@@ -74,10 +74,10 @@ extension ExplorerValueEncoder {
             try encoder.value.add(.data(value), at: path.appending(key.stringValue))
         }
 
-        mutating func encode<T>(_ value: T, forKey key: Key) throws where T : Encodable {
+        mutating func encode<T>(_ value: T, forKey key: Key) throws where T: Encodable {
             if let data = value as? Data {
                 try encode(data, forKey: key)
-                return 
+                return
             }
 
             let newEncoder = ExplorerValueEncoder()
@@ -85,7 +85,7 @@ extension ExplorerValueEncoder {
             try encoder.value.add(newEncoder.value, at: path.appending(key.stringValue))
         }
 
-        mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
+        mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> where NestedKey: CodingKey {
             KeyedEncodingContainer(Container<NestedKey>(codingPath: codingPath + [key], encoder: encoder, path: path.appending(key.stringValue)))
         }
 

--- a/Sources/Scout/ExplorerValueSerialization/ExplorerValueConvertible+Codable/Encoding/ExplorerValueSingleEncodingContainer.swift
+++ b/Sources/Scout/ExplorerValueSerialization/ExplorerValueConvertible+Codable/Encoding/ExplorerValueSingleEncodingContainer.swift
@@ -74,7 +74,7 @@ extension ExplorerValueEncoder {
             try encoder.value.set(path, to: .data(value))
         }
 
-        mutating func encode<T>(_ value: T) throws where T : Encodable {
+        mutating func encode<T>(_ value: T) throws where T: Encodable {
             if let data = value as? Data {
                 try encode(data)
                 return

--- a/Sources/Scout/ExplorerValueSerialization/ExplorerValueConvertible+Codable/Encoding/ExplorerValueUnkeyedEncodingContainer.swift
+++ b/Sources/Scout/ExplorerValueSerialization/ExplorerValueConvertible+Codable/Encoding/ExplorerValueUnkeyedEncodingContainer.swift
@@ -91,7 +91,7 @@ extension ExplorerValueEncoder {
             count += 1
         }
 
-        mutating func encode<T>(_ value: T) throws where T : Encodable {
+        mutating func encode<T>(_ value: T) throws where T: Encodable {
             if let data = value as? Data {
                 try encode(data)
                 return
@@ -103,7 +103,7 @@ extension ExplorerValueEncoder {
             count += 1
         }
 
-        mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
+        mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> where NestedKey: CodingKey {
             defer { count += 1 }
             return KeyedEncodingContainer(Container<NestedKey>(codingPath: codingPath, encoder: encoder, path: path.appending(.count)))
         }

--- a/Sources/Scout/Models/PathExplorer/CodableFormatPathExplorer.swift
+++ b/Sources/Scout/Models/PathExplorer/CodableFormatPathExplorer.swift
@@ -13,8 +13,8 @@ public struct CodableFormatPathExplorer<Format: CodableFormat>: PathExplorerBis 
     public var int: Int? { value.int }
     public var real: Double? { value.real }
     public var data: Data? { value.data }
-    public func array<T>(of type: T.Type) throws -> [T] where T : ExplorerValueCreatable { try value.array(of: type) }
-    public func dictionary<T>(of type: T.Type) throws -> [String : T] where T : ExplorerValueCreatable { try value.dictionary(of: type) }
+    public func array<T>(of type: T.Type) throws -> [T] where T: ExplorerValueCreatable { try value.array(of: type) }
+    public func dictionary<T>(of type: T.Type) throws -> [String: T] where T: ExplorerValueCreatable { try value.dictionary(of: type) }
 
     public var isGroup: Bool { value.isGroup }
     public var isSingle: Bool { value.isSingle }

--- a/Sources/Scout/Models/PathExplorer/CodableFormatPathExplorer.swift
+++ b/Sources/Scout/Models/PathExplorer/CodableFormatPathExplorer.swift
@@ -16,6 +16,9 @@ public struct CodableFormatPathExplorer<Format: CodableFormat>: PathExplorerBis 
     public func array<T>(of type: T.Type) throws -> [T] where T : ExplorerValueCreatable { try value.array(of: type) }
     public func dictionary<T>(of type: T.Type) throws -> [String : T] where T : ExplorerValueCreatable { try value.dictionary(of: type) }
 
+    public var isGroup: Bool { value.isGroup }
+    public var isSingle: Bool { value.isSingle }
+
     public var description: String { value.description }
     public var debugDescription: String { value.debugDescription }
 
@@ -102,7 +105,7 @@ extension CodableFormatPathExplorer: SerializablePathExplorer {
         case .json: return try CodableFormats.JsonDefault.encode(value)
         case .plist: return try CodableFormats.PlistDefault.encode(value)
         case .yaml: return try CodableFormats.YamlDefault.encode(value)
-        case .xml: return try CodableFormats.XmlDefault.encode(value)
+        case .xml: return try CodableFormats.XmlDefault.encode(value, rootName: rootName)
         }
     }
 
@@ -120,9 +123,9 @@ extension CodableFormatPathExplorer: SerializablePathExplorer {
         Self(value: value.folded(upTo: level))
     }
 
-    public func exportFoldedString(upTo level: Int) -> String {
-        folded(upTo: level)
-            .description
+    public func exportFoldedString(upTo level: Int) throws -> String {
+        try folded(upTo: level)
+            .exportString()
             .replacingOccurrences(of: Format.foldedRegexPattern, with: "...", options: .regularExpression)
     }
 }

--- a/Sources/Scout/Models/PathExplorer/PathExplorer+Namespace.swift
+++ b/Sources/Scout/Models/PathExplorer/PathExplorer+Namespace.swift
@@ -18,8 +18,8 @@ public enum PathExplorers {
     public typealias Plist = PathExplorerSerialization<SerializationFormats.Plist>
     public typealias Yaml = PathExplorerSerialization<SerializationFormats.Yaml>
 
-//    public typealias Xml = CodableFormatPathExplorer<CodableFormats.XmlDefault>
-//    public typealias Json = CodableFormatPathExplorer<CodableFormats.JsonDefault>
-//    public typealias Plist = CodableFormatPathExplorer<CodableFormats.PlistDefault>
-//    public typealias Yaml = CodableFormatPathExplorer<CodableFormats.YamlDefault>
+    public typealias XmlBis = CodableFormatPathExplorer<CodableFormats.XmlDefault>
+    public typealias JsonBis = CodableFormatPathExplorer<CodableFormats.JsonDefault>
+    public typealias PlistBis = CodableFormatPathExplorer<CodableFormats.PlistDefault>
+    public typealias YamlBis = CodableFormatPathExplorer<CodableFormats.YamlDefault>
 }

--- a/Sources/Scout/Models/PathExplorer/PathExplorerBis+Helpers.swift
+++ b/Sources/Scout/Models/PathExplorer/PathExplorerBis+Helpers.swift
@@ -1,0 +1,63 @@
+//
+// Scout
+// Copyright (c) Alexis Bridoux 2020
+// MIT license, see LICENSE file for details
+
+import Foundation
+
+extension PathExplorerBis {
+
+    /// Add the element to the thrown `ValueTypeError` if any
+    func doAdd<T>(_ element: PathElementRepresentable, _ block: () throws -> T) rethrows -> T {
+        do {
+            return try block()
+        } catch let error as ExplorerError {
+            throw error.adding(element)
+        }
+    }
+
+    /// Add the element to the thrown `ValueTypeError` if any
+    func doAdd(_ element: PathElementRepresentable, _ block: () throws -> Void) rethrows {
+        do {
+            try block()
+        } catch let error as ExplorerError {
+            throw error.adding(element)
+        }
+    }
+
+    /// Add the element to the thrown `ValueTypeError` if any
+    func doAdd<T>(_ element: PathElement, _ block: () throws -> T) rethrows -> T {
+        do {
+            return try block()
+        } catch let error as ExplorerError {
+            throw error.adding(element)
+        }
+    }
+
+    /// Add the element to the thrown `ValueTypeError` if any
+    func doAdd(_ element: PathElement, _ block: () throws -> Void) rethrows {
+        do {
+            try block()
+        } catch let error as ExplorerError {
+            throw error.adding(element)
+        }
+    }
+
+    /// do/catch on the provided block to catch a `ValueTypeError` and set the provided path on it
+    func doSettingPath(_ path: Slice<Path>, _ block: () throws -> Void) rethrows {
+        do {
+            try block()
+        } catch let error as ExplorerError {
+            throw error.with(path: path)
+        }
+    }
+
+    /// do/catch on the provided block to catch a `ValueTypeError` and set the provided path on it
+    func doSettingPath<T>(_ path: Slice<Path>, _ block: () throws -> T) rethrows -> T {
+        do {
+            return try block()
+        } catch let error as ExplorerError {
+            throw error.with(path: path)
+        }
+    }
+}

--- a/Sources/Scout/Models/PathExplorer/PathExplorerBis.swift
+++ b/Sources/Scout/Models/PathExplorer/PathExplorerBis.swift
@@ -40,6 +40,13 @@ where
     /// A dictionary of the provided type as values.
     func dictionary<T: ExplorerValueCreatable>(of type: T.Type) throws -> [String: T]
 
+
+    /// `true` if the explorer is a group value (e.g. a dictionary or an array)
+    var isGroup: Bool { get }
+
+    /// `true` if the explorer is a single value (e.g. a string, an int...)
+    var isSingle: Bool { get }
+
     // MARK: - Initialization
 
     init(value: ExplorerValue)

--- a/Sources/Scout/Models/PathExplorer/PathExplorerBis.swift
+++ b/Sources/Scout/Models/PathExplorer/PathExplorerBis.swift
@@ -40,7 +40,6 @@ where
     /// A dictionary of the provided type as values.
     func dictionary<T: ExplorerValueCreatable>(of type: T.Type) throws -> [String: T]
 
-
     /// `true` if the explorer is a group value (e.g. a dictionary or an array)
     var isGroup: Bool { get }
 

--- a/Sources/Scout/Models/PathExplorer/SerializablePathExplorer.swift
+++ b/Sources/Scout/Models/PathExplorer/SerializablePathExplorer.swift
@@ -7,6 +7,8 @@ import Foundation
 
 public protocol SerializablePathExplorer: PathExplorerBis {
 
+    associatedtype Format: CodableFormat
+
     /// Export the path explorer value to data
     func exportData() throws -> Data
 
@@ -33,7 +35,7 @@ public protocol SerializablePathExplorer: PathExplorerBis {
     func folded(upTo level: Int) -> Self
 
     /// Folded explored description, replacing the group values (array or dictionaries) sub values by a single string "..."
-    func exportFoldedString(upTo level: Int) -> String
+    func exportFoldedString(upTo level: Int) throws -> String
 }
 
 public extension SerializablePathExplorer {

--- a/Sources/Scout/Models/PathExplorer/SerializablePathExplorer.swift
+++ b/Sources/Scout/Models/PathExplorer/SerializablePathExplorer.swift
@@ -9,6 +9,8 @@ public protocol SerializablePathExplorer: PathExplorerBis {
 
     associatedtype Format: CodableFormat
 
+    init(data: Data) throws
+
     /// Export the path explorer value to data
     func exportData() throws -> Data
 

--- a/Sources/Scout/Models/SerializationFormats.swift
+++ b/Sources/Scout/Models/SerializationFormats.swift
@@ -54,9 +54,9 @@ extension SerializationFormats {
             }
 
             if #available(OSX 10.15, *) {
-                return try JSONSerialization.data(withJSONObject: value, options: [.prettyPrinted, .withoutEscapingSlashes])
+                return try JSONSerialization.data(withJSONObject: value, options: [.prettyPrinted, .withoutEscapingSlashes, .fragmentsAllowed])
             } else {
-                return try JSONSerialization.data(withJSONObject: value, options: [.prettyPrinted])
+                return try JSONSerialization.data(withJSONObject: value, options: [.prettyPrinted, .fragmentsAllowed])
             }
         }
     }

--- a/Sources/Scout/PathExplorerImplementations/ExplorerValue/ExplorerError.swift
+++ b/Sources/Scout/PathExplorerImplementations/ExplorerValue/ExplorerError.swift
@@ -9,7 +9,7 @@ public struct ExplorerError: LocalizedError, Equatable {
     public private(set) var path: Path
     let description: String
 
-    public var errorDescription: String? { "[\(path.description)] \(description)" }
+    public var errorDescription: String? { "'\(path.description)' \(description)" }
 
     init(path: Path = .empty, description: String) {
         self.path = path

--- a/Sources/Scout/PathExplorerImplementations/ExplorerValue/ExplorerValue+CSV.swift
+++ b/Sources/Scout/PathExplorerImplementations/ExplorerValue/ExplorerValue+CSV.swift
@@ -94,7 +94,7 @@ extension ExplorerValue {
     /// #### Complexity
     /// `O(n)` where `n` is the number of elements in the array
     private func headers(in array: ArrayValue) throws -> [Path] {
-        try array.reduce([Path]()) { (keys, value) in
+        try array.reduce([Path]()) { (_, value) in
             guard value.isDictionary else { throw ExplorerError.mismatchingType(DictionaryValue.self, value: value) }
             return try value.listPaths(filter: .targetOnly(.single))
         }

--- a/Sources/Scout/PathExplorerImplementations/ExplorerValue/ExplorerValue+Folded.swift
+++ b/Sources/Scout/PathExplorerImplementations/ExplorerValue/ExplorerValue+Folded.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 extension ExplorerValue {
-    
+
     private var foldedKey: String { Folding.foldedKey }
     private var foldedMark: String { Folding.foldedMark }
 

--- a/Sources/Scout/PathExplorerImplementations/ExplorerValue/ExplorerValue+Get.swift
+++ b/Sources/Scout/PathExplorerImplementations/ExplorerValue/ExplorerValue+Get.swift
@@ -41,6 +41,9 @@ extension ExplorerValue {
             let newDict = try dict.map { try ("\($0.key)_\(key)", $0.value.get(key: key)) }
             return filter <^> Dictionary(uniqueKeysWithValues: newDict)
 
+        case .slice(let array):
+            return try slice <^> array.map { try $0.get(key: key) }
+
         default:
             throw ExplorerError.subscriptKeyNoDict
         }

--- a/Sources/Scout/PathExplorerImplementations/ExplorerValue/ExplorerValue.swift
+++ b/Sources/Scout/PathExplorerImplementations/ExplorerValue/ExplorerValue.swift
@@ -70,7 +70,7 @@ extension ExplorerValue: Codable {
     public init(from decoder: Decoder) throws {
         if let dict = try? DictionaryValue(from: decoder) {
             self = .dictionary(dict)
-        } else if let array = try? ArrayValue(from: decoder){
+        } else if let array = try? ArrayValue(from: decoder) {
             self = .array(array)
         } else {
             self = try .decodeSingleValue(from: decoder)

--- a/Sources/ScoutCLT/Add/AddCommand.swift
+++ b/Sources/ScoutCLT/Add/AddCommand.swift
@@ -47,18 +47,33 @@ struct AddCommand: SADCommand {
 
     // MARK: - Functions
 
-    func perform<P: PathExplorer>(pathExplorer: inout P, pathCollectionElement: PathAndValue) throws {
+    func perform<P: PathExplorerBis>(pathExplorer: inout P, pathCollectionElement: PathAndValue) throws {
         let (path, value) = (pathCollectionElement.readingPath, pathCollectionElement.value)
 
+        let explorerValue: ExplorerValue
+
         if let forceType = pathCollectionElement.forceType {
+
             switch forceType {
-            case .string: try pathExplorer.add(value, at: path, as: .string)
-            case .real: try pathExplorer.add(value, at: path, as: .real)
-            case .int: try pathExplorer.add(value, at: path, as: .int)
-            case .bool: try pathExplorer.add(value, at: path, as: .bool)
+            case .string:
+                explorerValue = .string(value)
+
+            case .real:
+                let double = try Double(value).unwrapOrThrow(.valueConversion(value: value, type: "Double"))
+                explorerValue = .double(double)
+
+            case .int:
+                let int = try Int(value).unwrapOrThrow(.valueConversion(value: value, type: "Int"))
+                explorerValue = .int(int)
+
+            case .bool:
+                let bool = try Bool(value).unwrapOrThrow(.valueConversion(value: value, type: "Bool"))
+                explorerValue = .bool(bool)
             }
         } else {
-            try pathExplorer.add(value, at: path)
+            explorerValue = .init(fromSingle: value)
         }
+
+        try pathExplorer.add(explorerValue, at: path)
     }
 }

--- a/Sources/ScoutCLT/Add/AddCommand.swift
+++ b/Sources/ScoutCLT/Add/AddCommand.swift
@@ -18,6 +18,9 @@ struct AddCommand: SADCommand {
 
     // MARK: - Properties
 
+    @Flag(help: "The data format to read the input")
+    var dataFormat: DataFormat
+
     @Argument(help: PathAndValue.help)
     var pathsCollection = [PathAndValue]()
 

--- a/Sources/ScoutCLT/Delete/DeleteCommand.swift
+++ b/Sources/ScoutCLT/Delete/DeleteCommand.swift
@@ -50,7 +50,7 @@ struct DeleteCommand: SADCommand {
 
     // MARK: - Functions
 
-    func perform<P: PathExplorer>(pathExplorer: inout P, pathCollectionElement: Path) throws {
+    func perform<P: SerializablePathExplorer>(pathExplorer: inout P, pathCollectionElement: Path) throws {
         try pathExplorer.delete(pathCollectionElement, deleteIfEmpty: recursive)
     }
 }

--- a/Sources/ScoutCLT/Delete/DeleteCommand.swift
+++ b/Sources/ScoutCLT/Delete/DeleteCommand.swift
@@ -18,6 +18,9 @@ struct DeleteCommand: SADCommand {
 
     // MARK: - Properties
 
+    @Flag(help: "The data format to read the input")
+    var dataFormat: DataFormat
+
     @Argument(help: "Paths to indicate the keys to be deleted")
     var pathsCollection = [Path]()
 

--- a/Sources/ScoutCLT/Delete/DeleteKeyCommand.swift
+++ b/Sources/ScoutCLT/Delete/DeleteKeyCommand.swift
@@ -52,7 +52,7 @@ struct DeleteKeyCommand: SADCommand {
 
     // MARK: - Functions
 
-    func perform<P: PathExplorer>(pathExplorer: inout P, pathCollectionElement: Path) throws {
+    func perform<P: SerializablePathExplorer>(pathExplorer: inout P, pathCollectionElement: Path) throws {
         // postponed to 3.1.0
 
 //         will be called only once

--- a/Sources/ScoutCLT/Delete/DeleteKeyCommand.swift
+++ b/Sources/ScoutCLT/Delete/DeleteKeyCommand.swift
@@ -20,6 +20,9 @@ struct DeleteKeyCommand: SADCommand {
 
     var pathsCollection: [Path] { [Path("empty")] }
 
+    @Flag(help: "The data format to read the input")
+    var dataFormat: DataFormat
+
     @Argument(help: "The regular expression pattern the keys to delete have to match")
     var pattern: String
 

--- a/Sources/ScoutCLT/Extensions/DataFormat+ArgumentParser.swift
+++ b/Sources/ScoutCLT/Extensions/DataFormat+ArgumentParser.swift
@@ -1,0 +1,21 @@
+//
+// Scout
+// Copyright (c) Alexis Bridoux 2020
+// MIT license, see LICENSE file for details
+
+import Scout
+import ArgumentParser
+
+extension DataFormat: ExpressibleByArgument {}
+
+extension DataFormat: EnumerableFlag {
+
+    public static func name(for value: DataFormat) -> NameSpecification {
+        switch value {
+        case .json: return [.long, .customShort("J")]
+        case .plist: return [.long, .customShort("P")]
+        case .xml: return [.long, .customShort("X")]
+        case .yaml: return [.long, .customShort("Y")]
+        }
+    }
+}

--- a/Sources/ScoutCLT/Extensions/DataFormat+ParsableArgument.swift
+++ b/Sources/ScoutCLT/Extensions/DataFormat+ParsableArgument.swift
@@ -1,9 +1,0 @@
-//
-// Scout
-// Copyright (c) Alexis Bridoux 2020
-// MIT license, see LICENSE file for details
-
-import Scout
-import ArgumentParser
-
-extension DataFormat: ExpressibleByArgument {}

--- a/Sources/ScoutCLT/Extensions/ExplorerValue+Extensions.swift
+++ b/Sources/ScoutCLT/Extensions/ExplorerValue+Extensions.swift
@@ -1,0 +1,22 @@
+//
+// Scout
+// Copyright (c) Alexis Bridoux 2020
+// MIT license, see LICENSE file for details
+
+import Foundation
+import Scout
+
+extension ExplorerValue {
+
+    init(fromSingle string: String) {
+        if let int = Int(string) {
+            self = .int(int)
+        } else if let double = Double(string) {
+            self = .double(double)
+        } else if let bool = Bool(string) {
+            self = .bool(bool)
+        } else {
+            self = .string(string)
+        }
+    }
+}

--- a/Sources/ScoutCLT/Extensions/Optional+Extensions.swift
+++ b/Sources/ScoutCLT/Extensions/Optional+Extensions.swift
@@ -14,7 +14,7 @@ extension Optional {
         return wrapped
     }
 
-    func unwrapOrThrow(error: RuntimeError) throws -> Wrapped {
+    func unwrapOrThrow(_ error: RuntimeError) throws -> Wrapped {
         try unwrapOrThrow(error: error)
     }
 }

--- a/Sources/ScoutCLT/Extensions/ParsableCommand+PathCompletion.swift
+++ b/Sources/ScoutCLT/Extensions/ParsableCommand+PathCompletion.swift
@@ -11,13 +11,7 @@ protocol PathExplorerGet {
     func tryToGet(_ path: Path) throws
 }
 
-extension PathExplorerSerialization: PathExplorerGet {
-    func tryToGet(_ path: Path) throws {
-        _ = try get(path)
-    }
-}
-
-extension Xml: PathExplorerGet {
+extension CodableFormatPathExplorer: PathExplorerGet {
     func tryToGet(_ path: Path) throws {
         _ = try get(path)
     }

--- a/Sources/ScoutCLT/Main/ScoutCommand.swift
+++ b/Sources/ScoutCLT/Main/ScoutCommand.swift
@@ -17,7 +17,7 @@ protocol ScoutCommand: ParsableCommand {
     var modifyFilePath: String? { get }
 
     /// Called with the correct `PathExplorer` when `inferPathExplorer(from:in:)` completes
-    func inferred<P: PathExplorer>(pathExplorer: P) throws
+    func inferred<P: SerializablePathExplorer>(pathExplorer: P) throws
 }
 
 extension ScoutCommand {
@@ -50,6 +50,9 @@ extension ScoutCommand {
         // The function `readDataToEndOfFile()` was deprecated since macOS 10.15.4
         // but now (macOS 11.2.2) it seems to be deprecated for never (100_000)).
         return FileHandle.standardInput.readDataToEndOfFile()
+
+//        return try input.data(using: .utf8)
+//            .unwrapOrThrow(error: .invalidData("Unable to get data from standard input"))
 
 //        if #available(OSX 10.15.4, *) {
 //            do {

--- a/Sources/ScoutCLT/Main/ScoutCommand.swift
+++ b/Sources/ScoutCLT/Main/ScoutCommand.swift
@@ -72,24 +72,28 @@ extension ScoutCommand {
 //        }
     }
 
-    func makePathExplorer(for dataFormat: Scout.DataFormat, from data: Data) throws {
+    private func makeExplorer<P: SerializablePathExplorer>(_ type: P.Type, from data: Data) throws -> P {
         do {
-            switch dataFormat {
-            case .json:
-                let json = try Json(data: data)
-                try inferred(pathExplorer: json)
-            case .plist:
-                let plist = try Plist(data: data)
-                try inferred(pathExplorer: plist)
-            case .yaml:
-                let yaml = try Yaml(data: data)
-                try inferred(pathExplorer: yaml)
-            case .xml:
-                let xml = try Xml(data: data)
-                try inferred(pathExplorer: xml)
-            }
+            return try P(data: data)
         } catch {
-            throw RuntimeError.unknownFormat("The input cannot be read as \(dataFormat).\n\(error).\n\(error.localizedDescription)")
+            throw RuntimeError.unknownFormat("The input cannot be read as \(dataFormat).\n\(error.localizedDescription)")
+        }
+    }
+
+    func makePathExplorer(for dataFormat: Scout.DataFormat, from data: Data) throws {
+        switch dataFormat {
+        case .json:
+            let json = try makeExplorer(Json.self, from: data)
+            try inferred(pathExplorer: json)
+        case .plist:
+            let plist = try makeExplorer(Plist.self, from: data)
+            try inferred(pathExplorer: plist)
+        case .yaml:
+            let yaml = try makeExplorer(Yaml.self, from: data)
+            try inferred(pathExplorer: yaml)
+        case .xml:
+            let xml = try makeExplorer(Xml.self, from: data)
+            try inferred(pathExplorer: xml)
         }
     }
 

--- a/Sources/ScoutCLT/Models/PathExplorer+Alias.swift
+++ b/Sources/ScoutCLT/Models/PathExplorer+Alias.swift
@@ -5,7 +5,7 @@
 
 import Scout
 
-typealias Xml = PathExplorers.Xml
-typealias Json = PathExplorers.Json
-typealias Plist = PathExplorers.Plist
-typealias Yaml = PathExplorers.Yaml
+typealias Xml = PathExplorers.XmlBis
+typealias Json = PathExplorers.JsonBis
+typealias Plist = PathExplorers.PlistBis
+typealias Yaml = PathExplorers.YamlBis

--- a/Sources/ScoutCLT/Models/RuntimeError.swift
+++ b/Sources/ScoutCLT/Models/RuntimeError.swift
@@ -12,15 +12,17 @@ enum RuntimeError: LocalizedError {
     case completionScriptInstallation(description: String)
     case invalidRegex(String)
     case invalidArgumentsCombination(description: String)
+    case valueConversion(value: String, type: String)
 
     var errorDescription: String? {
         switch self {
         case .invalidData(let description): return description
         case .noValueAt(let path): return "No value at '\(path)'"
         case .unknownFormat(let description): return description
-        case .completionScriptInstallation(let description): return "Error while installating the completion script. \(description)"
+        case .completionScriptInstallation(let description): return "Error while installing the completion script. \(description)"
         case .invalidRegex(let pattern): return "The regular expression  '\(pattern)' is invalid"
         case .invalidArgumentsCombination(let description): return description
+        case .valueConversion(let value, let type): return "The value \(value) is not convertible to \(type)"
         }
     }
 }

--- a/Sources/ScoutCLT/Paths/PathsCommand.swift
+++ b/Sources/ScoutCLT/Paths/PathsCommand.swift
@@ -37,7 +37,7 @@ struct PathsCommand: ScoutCommand {
 
     // MARK: - Functions
 
-    func inferred<P>(pathExplorer: P) throws where P: PathExplorer {
+    func inferred<P>(pathExplorer: P) throws where P: PathExplorerBis {
         var pathsFilter = PathsFilter.targetOnly(valueTarget)
         let valuePredicates = self.valuePredicates.isEmpty ? nil : try self.valuePredicates.map { try PathsFilter.ExpressionPredicate(format: $0) }
         var keyRegex: NSRegularExpression?

--- a/Sources/ScoutCLT/Paths/PathsCommand.swift
+++ b/Sources/ScoutCLT/Paths/PathsCommand.swift
@@ -20,6 +20,9 @@ struct PathsCommand: ScoutCommand {
 
     // MARK: - Properties
 
+    @Flag(help: "The data format to read the input")
+    var dataFormat: DataFormat
+
     @Argument(help: "Initial path from which the paths should be listed")
     var initialPath: Path?
 

--- a/Sources/ScoutCLT/Read/ReadCommand.swift
+++ b/Sources/ScoutCLT/Read/ReadCommand.swift
@@ -31,6 +31,9 @@ struct ReadCommand: ScoutCommand, ExportCommand {
             && !FileHandle.standardOutput.isPiped
     }
 
+    @Flag(help: "The data format to read the input")
+    var dataFormat: Scout.DataFormat
+
     @Argument(help: .readingPath)
     var readingPath: Path?
 

--- a/Sources/ScoutCLT/Set/SetCommand.swift
+++ b/Sources/ScoutCLT/Set/SetCommand.swift
@@ -17,6 +17,9 @@ struct SetCommand: SADCommand {
 
     // MARK: - Properties
 
+    @Flag(help: "The data format to read the input")
+    var dataFormat: DataFormat
+
     @Argument(help: PathAndValue.help)
     var pathsCollection = [PathAndValue]()
 

--- a/Sources/ScoutCLT/Set/SetCommand.swift
+++ b/Sources/ScoutCLT/Set/SetCommand.swift
@@ -46,7 +46,7 @@ struct SetCommand: SADCommand {
 
     // MARK: - Functions
 
-    func perform<P: PathExplorer>(pathExplorer: inout P, pathCollectionElement: PathAndValue) throws {
+    func perform<P: SerializablePathExplorer>(pathExplorer: inout P, pathCollectionElement: PathAndValue) throws {
         let (path, value) = (pathCollectionElement.readingPath, pathCollectionElement.value)
 
         if pathCollectionElement.changeKey {
@@ -54,15 +54,30 @@ struct SetCommand: SADCommand {
             return
         }
 
+        let explorerValue: ExplorerValue
+
         if let forceType = pathCollectionElement.forceType {
+
             switch forceType {
-            case .string: try pathExplorer.set(path, to: value, as: .string)
-            case .real: try pathExplorer.set(path, to: value, as: .real)
-            case .int: try pathExplorer.set(path, to: value, as: .int)
-            case .bool: try pathExplorer.set(path, to: value, as: .bool)
+            case .string:
+                explorerValue = .string(value)
+
+            case .real:
+                let double = try Double(value).unwrapOrThrow(.valueConversion(value: value, type: "Double"))
+                explorerValue = .double(double)
+
+            case .int:
+                let int = try Int(value).unwrapOrThrow(.valueConversion(value: value, type: "Int"))
+                explorerValue = .int(int)
+
+            case .bool:
+                let bool = try Bool(value).unwrapOrThrow(.valueConversion(value: value, type: "Bool"))
+                explorerValue = .bool(bool)
             }
         } else {
-            try pathExplorer.set(path, to: value)
+            explorerValue = .init(fromSingle: value)
         }
+
+        try pathExplorer.set(path, to: explorerValue)
     }
 }

--- a/Tests/ScoutTests/ExplorerValueCoder/ExplorerValueDecoderTests.swift
+++ b/Tests/ScoutTests/ExplorerValueCoder/ExplorerValueDecoderTests.swift
@@ -77,4 +77,16 @@ final class ExplorerValueDecoderTests: XCTestCase {
         let expected = Toto(data: "here".data(using: .utf8)!)
         XCTAssertEqual(String(data: toto.data, encoding: .utf8), String(data: expected.data, encoding: .utf8))
     }
+
+    func testDecode_Nil() throws {
+        struct Toto: Codable, Equatable {
+            var string: String?
+        }
+
+        let value: ExplorerValue = [:]
+        let toto = try Toto(from: ExplorerValueDecoder(value))
+
+        let expected = Toto(string: nil)
+        XCTAssertEqual(toto, expected)
+    }
 }

--- a/Tests/ScoutTests/ExplorerValueCoder/ExplorerValueEncoderTests.swift
+++ b/Tests/ScoutTests/ExplorerValueCoder/ExplorerValueEncoderTests.swift
@@ -78,4 +78,16 @@ final class ExplorerValueEncoderTests: XCTestCase {
 
         XCTAssertEqual(encoder.value, ["data": .data(data)])
     }
+
+    func testEncode_Nil() throws {
+        struct Toto: Codable, Equatable {
+            var string: String?
+        }
+
+        let toto = Toto(string: nil)
+        let encoder = ExplorerValueEncoder()
+        try toto.encode(to: encoder)
+
+        XCTAssertEqual(encoder.value, [:])
+    }
 }

--- a/Tests/ScoutTests/PathExplorerTestsSuite/PathExplorerTests+CSVExport.swift
+++ b/Tests/ScoutTests/PathExplorerTestsSuite/PathExplorerTests+CSVExport.swift
@@ -23,13 +23,13 @@ final class PathExplorerCSVExportTests: XCTestCase {
     }
 
     func testStub() throws {
-        
+
     }
 
     func testExportCSV_SingleValues<P: SerializablePathExplorer>(_ type: P.Type) throws {
         try testExportCSV(
             P.self,
-            value:  ["Riri", "Fifi", "Loulou"],
+            value: ["Riri", "Fifi", "Loulou"],
             expected: "Riri;Fifi;Loulou;"
         )
     }
@@ -37,7 +37,7 @@ final class PathExplorerCSVExportTests: XCTestCase {
     func testExportCSV_ArrayOfDictionaries<P: SerializablePathExplorer>(_ type: P.Type) throws {
         try testExportCSV(
             P.self,
-            value:  [["name": "Riri", "age": 15], ["name": "Fifi", "age": 15], ["name": "Loulou", "age": 15]],
+            value: [["name": "Riri", "age": 15], ["name": "Fifi", "age": 15], ["name": "Loulou", "age": 15]],
             expected:
             """
             age;name;
@@ -51,7 +51,7 @@ final class PathExplorerCSVExportTests: XCTestCase {
     func testExportCSV_ArrayOfDictionaries_NestedDict<P: SerializablePathExplorer>(_ type: P.Type) throws {
         try testExportCSV(
             P.self,
-            value:  [["name": "Riri", "family": ["uncle": "Donald", "aunt": "Daisy"]],
+            value: [["name": "Riri", "family": ["uncle": "Donald", "aunt": "Daisy"]],
                      ["name": "Fifi", "family": ["uncle": "Donald", "aunt": "Daisy"]],
                      ["name": "Loulou", "family": ["uncle": "Donald", "aunt": "Daisy"]]],
             expected:
@@ -67,7 +67,7 @@ final class PathExplorerCSVExportTests: XCTestCase {
     func testExportCSV_ArrayOfDictionaries_NestedArray<P: SerializablePathExplorer>(_ type: P.Type) throws {
         try testExportCSV(
             P.self,
-            value:  [["name": "Riri", "brothers": ["Fifi", "Loulou"]],
+            value: [["name": "Riri", "brothers": ["Fifi", "Loulou"]],
                      ["name": "Fifi", "brothers": ["Riri", "Loulou"]],
                      ["name": "Loulou", "brothers": ["Riri", "Fifi"]]],
             expected:
@@ -83,7 +83,7 @@ final class PathExplorerCSVExportTests: XCTestCase {
     func testExportCSV_ArrayOfArrays<P: SerializablePathExplorer>(_ type: P.Type) throws {
         try testExportCSV(
             P.self,
-            value:  [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+            value: [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
             expected:
             """
             1;2;3;
@@ -96,7 +96,7 @@ final class PathExplorerCSVExportTests: XCTestCase {
     func testExportCSV_DictionaryOfArrays<P: SerializablePathExplorer>(_ type: P.Type) throws {
         try testExportCSV(
             P.self,
-            value:  ["duckFamily": ["Donald", "Daisy"], "mouseFamily": ["Mickey", "Minnie"]],
+            value: ["duckFamily": ["Donald", "Daisy"], "mouseFamily": ["Mickey", "Minnie"]],
             expected:
             """
             duckFamily;Donald;Daisy;
@@ -108,7 +108,7 @@ final class PathExplorerCSVExportTests: XCTestCase {
     func testExportCSV_SeparatorIsQuoted<P: SerializablePathExplorer>(_ type: P.Type) throws {
         try testExportCSV(
             P.self,
-            value:  ["phrase with; separator", "phrase without separator"],
+            value: ["phrase with; separator", "phrase without separator"],
             expected:
             """
             "phrase with; separator";phrase without separator;

--- a/Tests/ScoutTests/PathExplorerTestsSuite/PathExplorerTests+Get.swift
+++ b/Tests/ScoutTests/PathExplorerTestsSuite/PathExplorerTests+Get.swift
@@ -10,22 +10,17 @@ final class PathExplorerGetTests: XCTestCase {
 
     // MARK: - Properties
 
-    let dict: ExplorerValue = ["Endo": 2, "toto": true, "Riri": "duck", "score": 12.5]
-    let nestedDict: ExplorerValue = ["firstKey": ["secondKey": 23]]
-    let nestedNestedDict: ExplorerValue = ["firstKey": ["secondKey": ["thirdKey": 23]]]
-
     let woody: ExplorerValue = ["name": "Woody", "catchphrase": "I got a snake in my boot"]
     let buzz: ExplorerValue = ["name": "Buzz", "catchphrase": "To infinity and beyond"]
     let zorg: ExplorerValue = ["name": "Zorg", "catchphrase": "Destroy Buzz Lightyear"]
-
-    let array: ExplorerValue = ["Endo", 1, false, 2.5]
-    let ducks: ExplorerValue = ["Riri", "Fifi", "Loulou", "Donald", "Daisy"]
-    let matrix3x3: ExplorerValue = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
     // MARK: - Functions
 
     func test() throws {
         try test(ExplorerValue.self)
+        try testGetKey_NoDictionaryThrows_ValueType(ExplorerValue.self)
+    }
+
     }
 
     func test<P: EquatablePathExplorer>(_ type: P.Type) throws {
@@ -35,7 +30,6 @@ final class PathExplorerGetTests: XCTestCase {
         try testGetMissingKeyThrows_BestMatch(P.self)
         try testGetNestedKey(P.self)
         try testGetMissingNestedKeyThrows(P.self)
-        try testGetKeyNoDictionaryThrows_ValueType(P.self)
         try testGetKeyFilter(P.self)
 
         // index
@@ -75,7 +69,7 @@ final class PathExplorerGetTests: XCTestCase {
     // MARK: - Key
 
     func testGetKey<P: EquatablePathExplorer>(_ type: P.Type) throws {
-        let explorer = P(value: dict)
+        let explorer = P(value: ["Endo": 2, "toto": true, "Riri": "duck", "score": 12.5])
 
         try XCTAssertExplorersEqual(explorer.get("Endo"), 2)
         try XCTAssertExplorersEqual(explorer.get("toto"), true)
@@ -84,34 +78,34 @@ final class PathExplorerGetTests: XCTestCase {
     }
 
     func testGetMissingKeyThrows<P: EquatablePathExplorer>(_ type: P.Type) throws {
-        let explorer = P(value: dict)
+        let explorer = P(value: ["Endo": 2, "toto": true, "Riri": "duck", "score": 12.5])
 
         XCTAssertErrorsEqual(try explorer.get("Donald"),
                              .missing(key: "Donald", bestMatch: nil))
     }
 
     func testGetMissingKeyThrows_BestMatch<P: EquatablePathExplorer>(_ type: P.Type) throws {
-        let explorer = P(value: dict)
+        let explorer = P(value: ["Endo": 2, "toto": true, "Riri": "duck", "score": 12.5])
 
         XCTAssertErrorsEqual(try explorer.get("tata"),
                              ExplorerError.missing(key: "tata", bestMatch: "toto"))
     }
 
     func testGetNestedKey<P: EquatablePathExplorer>(_ type: P.Type) throws {
-        let explorer = P(value: nestedDict)
+        let explorer = P(value: ["firstKey": ["secondKey": 23]])
 
         XCTAssertEqual(try explorer.get("firstKey", "secondKey").int, 23)
     }
 
     func testGetMissingNestedKeyThrows<P: PathExplorerBis>(_ type: P.Type) throws {
-        let explorer = P(value: nestedDict)
+        let explorer = P(value: ["firstKey": ["secondKey": 23]])
 
         XCTAssertErrorsEqual(try explorer.get("firstKey", "kirk"),
                         ExplorerError.missing(key: "kirk", bestMatch: nil).with(path: "firstKey"))
     }
 
-    func testGetKeyNoDictionaryThrows_ValueType<P: EquatablePathExplorer>(_ type: P.Type) throws {
-        let explorer = P(value: array)
+    func testGetKey_NoDictionaryThrows_ValueType<P: EquatablePathExplorer>(_ type: P.Type) throws {
+        let explorer = P(value: ["Endo", 1, false, 2.5])
 
         XCTAssertErrorsEqual(try explorer.get("toto"), .subscriptKeyNoDict)
     }
@@ -119,18 +113,18 @@ final class PathExplorerGetTests: XCTestCase {
     // MARK: Filter
 
     func testGetKeyFilter<P: EquatablePathExplorer>(_ type: P.Type) throws {
-        let dict: ExplorerValue = ["woody": woody, "buzz": buzz, "zorg": zorg]
-        let expectedExplorer = P(value: .filter(["woody_name": "Woody", "buzz_name": "Buzz"]))
-
-        let explorer = try P(value: dict).get(.filter("woody|buzz"), "name")
-
-        XCTAssertExplorersEqual(explorer, expectedExplorer)
+        try testGet(
+            P.self,
+            value: ["woody": woody, "buzz": buzz, "zorg": zorg],
+            path: .filter("woody|buzz"), "name",
+            expected: .filter(["woody_name": "Woody", "buzz_name": "Buzz"])
+        )
     }
 
     // MARK: - Index
 
     func testGetIndex<P: EquatablePathExplorer>(_ type: P.Type) throws {
-        let explorer = P(value: array)
+        let explorer = P(value: ["Endo", 1, false, 2.5])
 
         XCTAssertEqual(try explorer.get(0).string, "Endo")
         XCTAssertEqual(try explorer.get(1).int, 1)
@@ -139,19 +133,19 @@ final class PathExplorerGetTests: XCTestCase {
     }
 
     func testGetLastIndex<P: EquatablePathExplorer>(_ type: P.Type) throws {
-        let explorer = P(value: array)
+        let explorer = P(value: ["Endo", 1, false, 2.5])
 
         try XCTAssertExplorersEqual(explorer.get(-1), 2.5)
     }
 
     func testGetNegativeIndex<P: EquatablePathExplorer>(_ type: P.Type) throws {
-        let explorer = P(value: array)
+        let explorer = P(value: ["Endo", 1, false, 2.5])
 
         try XCTAssertExplorersEqual(explorer.get(-2), false)
     }
 
     func testGetIndexNoArrayThrows<P: EquatablePathExplorer>(_ type: P.Type) throws {
-        let explorer = P(value: dict)
+        let explorer = P(value: ["Endo": 2, "toto": true, "Riri": "duck", "score": 12.5])
 
         XCTAssertErrorsEqual(try explorer.get(1), .subscriptIndexNoArray)
     }
@@ -159,29 +153,37 @@ final class PathExplorerGetTests: XCTestCase {
     // MARK: Slice
 
     func testGetIndexSlice<P: EquatablePathExplorer>(_ type: P.Type) throws {
-        let explorer = P(value: matrix3x3)
-        let expectedExplorer = P(value: .slice([2, 5]))
-
-        try XCTAssertExplorersEqual(explorer.get(.slice(0, 1), 1), expectedExplorer)
+        try testGet(
+            P.self,
+            value: [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+            path: .slice(0, 1), 1,
+            expected: .slice([2, 5])
+        )
     }
 
     // MARK: - Count
 
     func testGetArrayCount<P: EquatablePathExplorer>(_ type: P.Type) throws {
-        let explorer = P(value: array)
-        let expectedExplorer = P(value: .count(4))
-
-        try XCTAssertExplorersEqual(explorer.get(.count), expectedExplorer)
+        try testGet(
+            P.self,
+            value: ["Endo", 1, false, 2.5],
+            path: .count,
+            expected: .count(4)
+        )
     }
 
     func testGetDictionaryCount<P: EquatablePathExplorer>(_ type: P.Type) throws {
-        let explorer = P(value: dict)
-        let expectedExplorer = P(value: .count(4))
-
-        try XCTAssertExplorersEqual(explorer.get(.count), expectedExplorer)
+        try testGet(
+            P.self,
+            value: ["Endo": 2, "toto": true, "Riri": "duck", "score": 12.5],
+            path: .count,
+            expected: .count(4)
+        )
     }
 
     func testGetCountOnNonGroupThrows() throws {
+        let array: ExplorerValue = ["Endo", 1, false, 2.5]
+
         XCTAssertErrorsEqual(try array.get(0, .count),
                              ExplorerError.wrongUsage(of: .count).with(path: 0))
     }
@@ -189,14 +191,16 @@ final class PathExplorerGetTests: XCTestCase {
     // MARK: - Keys list
 
     func testGetKeysList<P: EquatablePathExplorer>(_ type: P.Type) throws {
-        let explorer = P(value: dict)
-        let expectedExplorer = P(value: .keysList(["Endo", "toto", "Riri", "score"]))
-
-        try XCTAssertExplorersEqual(explorer.get(.keysList), expectedExplorer)
+        try testGet(
+            P.self,
+            value: ["Endo": 2, "toto": true, "Riri": "duck", "score": 12.5],
+            path: .keysList,
+            expected: .keysList(["Endo", "toto", "Riri", "score"])
+        )
     }
 
     func testGetKeysListOnNonDictionaryThrows<P: EquatablePathExplorer>(_ type: P.Type) throws {
-        let explorer = P(value: array)
+        let explorer = P(value: ["Endo", 1, false, 2.5])
 
         XCTAssertErrorsEqual(try explorer.get(.keysList), .wrongUsage(of: .keysList))
     }
@@ -204,64 +208,97 @@ final class PathExplorerGetTests: XCTestCase {
     // MARK: - Filter
 
     func testGetFilter<P: EquatablePathExplorer>(_ type: P.Type) throws {
-        let dict: ExplorerValue = ["Tom": 10, "Robert": true, "Suzanne": "Here"]
-        let explorer = P(value: dict)
-        let expectedExplorer = P(value: .filter(["Tom": 10, "Robert": true]))
-
-        try XCTAssertExplorersEqual(explorer.get(.filter("Tom|Robert")), expectedExplorer)
+        try testGet(
+            P.self,
+            value: ["Tom": 10, "Robert": true, "Suzanne": "Here"],
+            path: .filter("Tom|Robert"),
+            expected: .filter(["Tom": 10, "Robert": true])
+        )
     }
 
     func testGetFilterOfFilter<P: EquatablePathExplorer>(_ type: P.Type) throws {
-        let dict: ExplorerValue = ["woody": woody, "buzz": buzz, "zorg": zorg]
-        let explorer = P(value: dict)
-        let expectedOutcome: ExplorerValue = .filter(["woody": .filter(["name": "Woody"]), "zorg": .filter(["name": "Zorg"])])
-        let expectedExplorer = P(value: expectedOutcome)
 
-        try XCTAssertExplorersEqual(explorer.get(.filter("woody|zorg"), .filter("name")), expectedExplorer)
+        try testGet(
+            P.self,
+            value: ["woody": woody, "buzz": buzz, "zorg": zorg],
+            path: .filter("woody|zorg"), .filter("name"),
+            expected: .filter(
+                ["woody": .filter(["name": "Woody"]),
+                 "zorg": .filter(["name": "Zorg"])]
+                )
+        )
     }
 
     func testGetFilterOnSlice<P: EquatablePathExplorer>(_ type: P.Type) throws {
-        let array: ExplorerValue = [woody, buzz, zorg]
-        let explorer = P(value: array)
-        let expectedOutcome: ExplorerValue = .slice([.filter(["name": "Woody"]), .filter(["name": "Buzz"])])
-        let expectedExplorer = P(value: expectedOutcome)
-
-        try XCTAssertExplorersEqual(explorer.get(.slice(0, 1), .filter("name")), expectedExplorer)
+        try testGet(
+            P.self,
+            value: [woody, buzz, zorg],
+            path: .slice(0, 1), .filter("name"),
+            expected: .slice(
+                [.filter(["name": "Woody"]), .filter(["name": "Buzz"])]
+            )
+        )
     }
 
     func testGetFilterOnNonDictionaryThrows<P: EquatablePathExplorer>(_ type: P.Type) throws {
-        let explorer = P(value: array)
-        XCTAssertErrorsEqual(try explorer.get(.filter("toto")), .wrongUsage(of: .filter("toto")))
+        let explorer = P(value: ["Endo", 1, false, 2.5])
+        XCTAssertErrorsEqual(try explorer.get(.filter("toto")),
+                             .wrongUsage(of: .filter("toto"))
+        )
     }
 
     // MARK: - Slice
 
     func testGetSlice<P: EquatablePathExplorer>(_ type: P.Type) throws {
-        let explorer = P(value: ducks)
-        let expectedExplorer = P(value: .slice(["Fifi", "Loulou", "Donald"]))
-
-        try XCTAssertExplorersEqual(explorer.get(.slice(1, -2)), expectedExplorer)
+        try testGet(
+            P.self,
+            value: ["Riri", "Fifi", "Loulou", "Donald", "Daisy"],
+            path: .slice(1, -2),
+            expected: .slice(["Fifi", "Loulou", "Donald"])
+        )
     }
 
     func testGetSliceOfSlice<P: EquatablePathExplorer>(_ type: P.Type) throws {
-        let explorer = P(value: matrix3x3)
-        let expectedExplorer = P(value: .slice([.slice([2, 3]), .slice([5, 6])]))
-
-        try XCTAssertExplorersEqual(explorer.get(.slice(0, 1), .slice(1, 2)), expectedExplorer)
+        try testGet(
+            P.self,
+            value: ["Riri", "Fifi", "Loulou", "Donald", "Daisy"],
+            path: .slice(1, -2),
+            expected: .slice(["Fifi", "Loulou", "Donald"])
+        )
     }
 
     func testGetSliceOnFilter<P: EquatablePathExplorer>(_ type: P.Type) throws {
-        let dict: ExplorerValue = ["first": ducks, "second": ducks]
-        let explorer = P(value: dict)
-        let expectedOutcome: ExplorerValue = .filter(["first": .slice(["Fifi", "Loulou"])])
-        let expectedExplorer = P(value: expectedOutcome)
-
-        try XCTAssertExplorersEqual(explorer.get(.filter("first"), .slice(1, 2)), expectedExplorer)
+        try testGet(
+            P.self,
+            value: ["first": ["Riri", "Fifi", "Loulou", "Donald", "Daisy"],
+                    "second": ["Riri", "Fifi", "Loulou", "Donald", "Daisy"]],
+            path: .filter("first"), .slice(1, 2),
+            expected: .filter(["first": .slice(["Fifi", "Loulou"])])
+        )
     }
 
     func testGetSliceOnNonArrayThrows<P: EquatablePathExplorer>(_ type: P.Type) throws {
-        let explorer = P(value: dict)
+        let explorer = P(value: ["Tom": 10, "Robert": true, "Suzanne": "Here"])
 
         XCTAssertErrorsEqual(try explorer.get(.slice(0, 1)), .wrongUsage(of: .slice(0, 1)))
+    }
+}
+
+// MARK: - Helpers
+
+extension PathExplorerGetTests {
+
+    func testGet<P: EquatablePathExplorer>(
+        _ type: P.Type,
+        value: ExplorerValue,
+        path: PathElement...,
+        expected: ExplorerValue,
+        file: StaticString = #file,
+        line: UInt = #line)
+    throws {
+        let explorer = P(value: value)
+        let expected = P(value: expected)
+
+        try XCTAssertExplorersEqual(explorer.get(path), expected, file: file, line: line)
     }
 }

--- a/Tests/ScoutTests/PathExplorerTestsSuite/PathExplorerTests+Get.swift
+++ b/Tests/ScoutTests/PathExplorerTestsSuite/PathExplorerTests+Get.swift
@@ -21,8 +21,6 @@ final class PathExplorerGetTests: XCTestCase {
         try testGetKey_NoDictionaryThrows_ValueType(ExplorerValue.self)
     }
 
-    }
-
     func test<P: EquatablePathExplorer>(_ type: P.Type) throws {
         // key
         try testGetKey(P.self)


### PR DESCRIPTION
# Summary

- CLT now uses new path explorers. Also, the data format is now required to read the input.
- Refactored PathExplorerGet tests
- Nil coding strategy for ExplorerValue
