### PR TITLE
Fixed adding on single values arrays

### DIFF
--- a/Sources/Scout/ExplorerValue/ExplorerValue+Add.swift
+++ b/Sources/Scout/ExplorerValue/ExplorerValue+Add.swift
@@ -52,7 +52,7 @@ extension ExplorerValue {
         let index = try computeIndex(from: index, arrayCount: array.count)
         let newValue = try array[index]._add(path: remainder, value: value)
 
-        if remainder.isEmpty {
+        if array.allSatisfy(\.isSingle) {
             #warning("This behavior is the current one but is strange. A new PathElement should be offered to differentiate between insertion and modification")
             array.insert(newValue, at: index)
         } else {

--- a/Sources/Scout/ExplorerXML/ExplorerXML+Add.swift
+++ b/Sources/Scout/ExplorerXML/ExplorerXML+Add.swift
@@ -55,9 +55,9 @@ extension ExplorerXML {
     private func add(value: ValueSetter, at index: Int, remainder: SlicePath) throws {
         let index = try computeIndex(from: index, arrayCount: childrenCount)
 
-        if remainder.isEmpty {
+        if children.allSatisfy(\.isSingle) {
             let childToInsert = ExplorerXML(name: childrenName)
-            childToInsert.set(value: value)
+            try childToInsert._add(value: value, at: remainder)
             var newChildren = children
             newChildren.insert(childToInsert, at: index)
             removeChildrenFromParent()

--- a/Tests/ScoutTests/PathExplorerTestsSuite/PathExplorerTests+Add.swift
+++ b/Tests/ScoutTests/PathExplorerTestsSuite/PathExplorerTests+Add.swift
@@ -191,7 +191,7 @@ final class PathExplorerAddTests: XCTestCase {
             initial: [1, 2],
             path: 0, .count,
             value: "here",
-            expected: [["here"], 2]
+            expected: [["here"], 1, 2]
         )
     }
 }


### PR DESCRIPTION
The check was made on the path remainder and not the children singularity.
