### PR TITLE
[#181] CSV import

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -47,6 +47,15 @@
         }
       },
       {
+        "package": "SwiftCSV",
+        "repositoryURL": "https://github.com/swiftcsv/SwiftCSV",
+        "state": {
+          "branch": null,
+          "revision": "ad2042d0ba2ea260246b0e1b1d5710cbc53e2836",
+          "version": "0.6.0"
+        }
+      },
+      {
         "package": "SwiftSoup",
         "repositoryURL": "https://github.com/scinfu/SwiftSoup.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -32,6 +32,9 @@ let package = Package(
             url: "https://github.com/jpsim/Yams.git",
             from: "4.0.0"),
         .package(
+            url: "https://github.com/swiftcsv/SwiftCSV",
+            from: "0.6.0"),
+        .package(
             url: "https://github.com/ABridoux/BooleanExpressionEvaluation",
             from: "2.0.0")
     ],
@@ -41,6 +44,7 @@ let package = Package(
             dependencies: [
                 "AEXML",
                 "Yams",
+                "SwiftCSV",
                 "BooleanExpressionEvaluation"]),
         .target(
             name: "ScoutCLTCore",

--- a/Sources/Scout/ExplorerValue/ExplorerValue+Add.swift
+++ b/Sources/Scout/ExplorerValue/ExplorerValue+Add.swift
@@ -48,6 +48,11 @@ extension ExplorerValue {
 
     private func add(index: Int, value: ExplorerValue, tail: SlicePath) throws -> ExplorerValue {
         var array = try self.array.unwrapOrThrow(.subscriptIndexNoArray)
+
+        if index == array.count {
+            return try addCount(value: value, tail: tail)
+        }
+
         let index = try computeIndex(from: index, arrayCount: array.count)
         let newValue = try array[index]._add(path: tail, value: value)
 

--- a/Sources/Scout/ExplorerValue/ExplorerValue+CSVExport.swift
+++ b/Sources/Scout/ExplorerValue/ExplorerValue+CSVExport.swift
@@ -53,7 +53,7 @@ extension ExplorerValue {
             .toCSV(separator: separator) + "\n"
 
         var csvString = arrayOfDictionaries.reduce(headersLine) { (csvString, value) in
-            let line = value.exploreReduce(initial: "", paths: headers) { (csvString, result) in
+            let line = value.reduceWithMemory(initial: "", paths: headers) { (csvString, result) in
 
                 let string: String
                 switch result {

--- a/Sources/Scout/ExplorerValue/ExplorerValue+CSVImport.swift
+++ b/Sources/Scout/ExplorerValue/ExplorerValue+CSVImport.swift
@@ -1,0 +1,42 @@
+//
+// Scout
+// Copyright (c) 2020-present Alexis Bridoux
+// MIT license, see LICENSE file for details
+
+import Foundation
+import SwiftCSV
+
+extension ExplorerValue {
+
+    static func fromCSV(string: String, separator: Character, hasHeaders: Bool) throws -> ExplorerValue {
+        let csv = try CSV(string: string, delimiter: separator, loadColumns: hasHeaders)
+        return try from(csv: csv, headers: hasHeaders)
+    }
+
+    private static func from(csv: CSV, headers: Bool) throws -> ExplorerValue {
+        if headers {
+            return try fromArrayOfDictionaries(csv: csv)
+        } else if csv.enumeratedRows.count == 1 {
+            return .array(csv.enumeratedRows[0].map(ExplorerValue.singleFrom))
+        } else {
+            return array <^> ([csv.header] + csv.enumeratedRows).map { array <^> $0.map(ExplorerValue.singleFrom) }
+        }
+    }
+
+    private static func fromArrayOfDictionaries(csv: CSV) throws -> ExplorerValue {
+        let headers = try csv.header.map { try (key: $0, path: Path(string: $0)) }.sorted { $0.path.comparedByKeyAndIndexes(with: $1.path) }
+        let dicts = try csv.namedRows.map { row -> ExplorerValue in try from(row: row, with: headers) }
+        return .array(dicts)
+    }
+
+    private static func from(row: [String: String], with headers: [(key: String, path: Path)]) throws -> ExplorerValue {
+        var dict = ExplorerValue.dictionary([:])
+
+        try headers.forEach { (key, path) in
+            guard let value = row[key] else { return }
+            try dict.add(.singleFrom(string: value), at: path)
+        }
+
+        return dict
+    }
+}

--- a/Sources/Scout/ExplorerValue/ExplorerValue+Helpers.swift
+++ b/Sources/Scout/ExplorerValue/ExplorerValue+Helpers.swift
@@ -14,9 +14,7 @@ extension PathExplorer {
     func computeIndex(from index: Int, arrayCount: Int) throws -> Int {
         let computedIndex = index < 0 ? arrayCount + index : index
 
-        if computedIndex == 0 && arrayCount == 0 {
-            return 0
-        }
+        if computedIndex == 0 && arrayCount == 0 { return 0 }
 
         guard 0 <= computedIndex, computedIndex < arrayCount else {
             throw ExplorerError.wrong(index: index, arrayCount: arrayCount)

--- a/Sources/Scout/ExplorerValue/ExplorerValue.swift
+++ b/Sources/Scout/ExplorerValue/ExplorerValue.swift
@@ -158,7 +158,7 @@ extension ExplorerValue: Codable {
     }
 }
 
-// MARK: - Any
+// MARK: - Special init
 
 extension ExplorerValue {
 
@@ -180,6 +180,13 @@ extension ExplorerValue {
         } else {
             throw ExplorerError.invalid(value: value)
         }
+    }
+
+    static func singleFrom(string: String) -> ExplorerValue {
+        if let int = Int(string) { return .int(int) }
+        else if let double = Double(string) { return .double(double) }
+        else if let bool = Bool(string) { return .bool(bool) }
+        else { return .string(string) }
     }
 }
 

--- a/Sources/Scout/ExplorerValue/ExplorerValue.swift
+++ b/Sources/Scout/ExplorerValue/ExplorerValue.swift
@@ -183,10 +183,7 @@ extension ExplorerValue {
     }
 
     static func singleFrom(string: String) -> ExplorerValue {
-        if let int = Int(string) { return .int(int) }
-        else if let double = Double(string) { return .double(double) }
-        else if let bool = Bool(string) { return .bool(bool) }
-        else { return .string(string) }
+        if let int = Int(string) { return .int(int) } else if let double = Double(string) { return .double(double) } else if let bool = Bool(string) { return .bool(bool) } else { return .string(string) }
     }
 }
 

--- a/Sources/Scout/ExplorerXML/ExplorerXML+Add.swift
+++ b/Sources/Scout/ExplorerXML/ExplorerXML+Add.swift
@@ -55,7 +55,7 @@ extension ExplorerXML {
         if index == childrenCount {
             return try addCount(value: value, tail: tail)
         }
-        
+
         let index = try computeIndex(from: index, arrayCount: childrenCount)
 
         guard children.allSatisfy(\.isSingle) else {

--- a/Sources/Scout/ExplorerXML/ExplorerXML+Add.swift
+++ b/Sources/Scout/ExplorerXML/ExplorerXML+Add.swift
@@ -52,6 +52,10 @@ extension ExplorerXML {
     }
 
     private func add(value: ValueSetter, at index: Int, tail: SlicePath) throws {
+        if index == childrenCount {
+            return try addCount(value: value, tail: tail)
+        }
+        
         let index = try computeIndex(from: index, arrayCount: childrenCount)
 
         guard children.allSatisfy(\.isSingle) else {

--- a/Sources/Scout/ExplorerXML/ExplorerXML+CSVExport.swift
+++ b/Sources/Scout/ExplorerXML/ExplorerXML+CSVExport.swift
@@ -52,7 +52,7 @@ extension ExplorerXML {
         let headersLine = headers.reduce("") { "\($0)\($1.description.escapingCSV(separator))\(separator)" } + "\n"
 
         var csvString = children.reduce(headersLine) { (csvString, explorer) in
-            let line = explorer.exploreReduce(initial: "", paths: headers) { (csvString, result) in
+            let line = explorer.reduceWithMemory(initial: "", paths: headers) { (csvString, result) in
 
                 let string: String
                 switch result {

--- a/Sources/Scout/ExplorerXML/ExplorerXML+CSVImport.swift
+++ b/Sources/Scout/ExplorerXML/ExplorerXML+CSVImport.swift
@@ -1,0 +1,13 @@
+//
+// Scout
+// Copyright (c) 2020-present Alexis Bridoux
+// MIT license, see LICENSE file for details
+
+import AEXML
+
+extension ExplorerXML {
+
+    public static func fromCSV(string: String, separator: Character, hasHeaders: Bool) throws -> ExplorerXML {
+        ExplorerXML(value: "")
+    }
+}

--- a/Sources/Scout/ExplorerXML/ExplorerXML+CSVImport.swift
+++ b/Sources/Scout/ExplorerXML/ExplorerXML+CSVImport.swift
@@ -8,6 +8,8 @@ import SwiftCSV
 
 extension ExplorerXML {
 
+    private typealias Tree = PathTree<String?>
+
     public static func fromCSV(string: String, separator: Character, hasHeaders: Bool) throws -> ExplorerXML {
         let csv = try CSV(string: string, delimiter: separator, loadColumns: hasHeaders)
         return try from(csv: csv, headers: hasHeaders)
@@ -16,13 +18,16 @@ extension ExplorerXML {
     private static func from(csv: CSV, headers: Bool) throws -> ExplorerXML {
         if headers {
             return try fromArrayOfDictionaries(csv: csv)
+
         } else if csv.enumeratedRows.count == 1 {
             let explorer = ExplorerXML(name: Element.defaultName)
             csv.enumeratedRows[0].forEach { explorer.addChild(ExplorerXML(name: Element.defaultName, value: $0)) }
             return explorer
+
         } else {
             let explorer = ExplorerXML(name: Element.defaultName)
             let rows = [csv.header] + csv.enumeratedRows
+
             rows.forEach { row in
                 let childArray = ExplorerXML(name: Element.defaultName)
                 row.forEach { childArray.addChild(ExplorerXML(name: Element.defaultName, value: $0)) }
@@ -34,26 +39,31 @@ extension ExplorerXML {
     }
 
     private static func fromArrayOfDictionaries(csv: CSV) throws -> ExplorerXML {
-        let headers = try csv.header.map { try (key: $0, path: Path(string: $0)) }.sorted { $0.path.comparedByKeyAndIndexes(with: $1.path) }
+        let rootTree = Tree.root()
+        let headers = try csv.header
+            .map { try (key: $0, path: Path(string: $0)) } // transform keys to paths
+            .sorted { $0.path.comparedByKeyAndIndexes(with: $1.path) } // sort by path
+            .map { ($0.key, rootTree.insert(path: $0.path)) } // insert paths in the tree
 
         let explorer = ExplorerXML(name: Element.defaultName)
 
         try csv.namedRows.forEach { row in
-            let child = try from(row: row, with: headers)
+            let child = try from(row: row, with: headers, rootTree: rootTree)
             explorer.addChild(child)
         }
 
         return explorer
     }
 
-    private static func from(row: [String: String], with headers: [(key: String, path: Path)]) throws -> ExplorerXML {
-        var explorer = ExplorerXML(value: [:])
-
-        try headers.forEach { (key, path) in
-            guard let value = row[key] else { return }
-            try explorer.add(.singleFrom(string: value), at: path)
+    private static func from(row: [String: String], with keysTrees: [(key: String, path: Tree)], rootTree: Tree) throws -> ExplorerXML {
+        keysTrees.forEach { (key, tree) in
+            if let value = row[key] {
+                tree.value = .leaf(value: value)
+            } else {
+                tree.value = .leaf(value: nil)
+            }
         }
 
-        return explorer
+        return try .newValue(exploring: rootTree)
     }
 }

--- a/Sources/Scout/ExplorerXML/ExplorerXML+CSVImport.swift
+++ b/Sources/Scout/ExplorerXML/ExplorerXML+CSVImport.swift
@@ -4,10 +4,56 @@
 // MIT license, see LICENSE file for details
 
 import AEXML
+import SwiftCSV
 
 extension ExplorerXML {
 
     public static func fromCSV(string: String, separator: Character, hasHeaders: Bool) throws -> ExplorerXML {
-        ExplorerXML(value: "")
+        let csv = try CSV(string: string, delimiter: separator, loadColumns: hasHeaders)
+        return try from(csv: csv, headers: hasHeaders)
+    }
+
+    private static func from(csv: CSV, headers: Bool) throws -> ExplorerXML {
+        if headers {
+            return try fromArrayOfDictionaries(csv: csv)
+        } else if csv.enumeratedRows.count == 1 {
+            let explorer = ExplorerXML(name: Element.defaultName)
+            csv.enumeratedRows[0].forEach { explorer.addChild(ExplorerXML(name: Element.defaultName, value: $0)) }
+            return explorer
+        } else {
+            let explorer = ExplorerXML(name: Element.defaultName)
+            let rows = [csv.header] + csv.enumeratedRows
+            rows.forEach { row in
+                let childArray = ExplorerXML(name: Element.defaultName)
+                row.forEach { childArray.addChild(ExplorerXML(name: Element.defaultName, value: $0)) }
+                explorer.addChild(childArray)
+            }
+
+            return explorer
+        }
+    }
+
+    private static func fromArrayOfDictionaries(csv: CSV) throws -> ExplorerXML {
+        let headers = try csv.header.map { try (key: $0, path: Path(string: $0)) }.sorted { $0.path.comparedByKeyAndIndexes(with: $1.path) }
+
+        let explorer = ExplorerXML(name: Element.defaultName)
+
+        try csv.namedRows.forEach { row in
+            let child = try from(row: row, with: headers)
+            explorer.addChild(child)
+        }
+
+        return explorer
+    }
+
+    private static func from(row: [String: String], with headers: [(key: String, path: Path)]) throws -> ExplorerXML {
+        var explorer = ExplorerXML(value: [:])
+
+        try headers.forEach { (key, path) in
+            guard let value = row[key] else { return }
+            try explorer.add(.singleFrom(string: value), at: path)
+        }
+
+        return explorer
     }
 }

--- a/Sources/Scout/ExplorerXML/ExplorerXML+ExplorerValue.swift
+++ b/Sources/Scout/ExplorerXML/ExplorerXML+ExplorerValue.swift
@@ -1,0 +1,92 @@
+//
+// Scout
+// Copyright (c) 2020-present Alexis Bridoux
+// MIT license, see LICENSE file for details
+
+extension ExplorerXML {
+
+    /// The `ExplorerValue` conversion of the XML element
+    ///
+    /// - Parameters:
+    ///     - keepingAttributes: `true` when the attributes should be included as data
+    ///     - singleChildStrategy: Specify how single children should be treated, as they can represent an array or a dictionary.
+    /// ### Complexity
+    /// `O(n)`  where `n` is the sum of all children
+    ///
+    /// ### Attributes
+    /// If a XML element has attributes and `keepingAttributes` is `true`,
+    /// the format of the returned `ExplorerValue` will be modified to
+    /// a dictionary with two keys:"attributes" which holds the attributes of the element as `[String: String]`
+    /// and "value" which holds the `ExplorerValue` conversion of the element.
+    ///
+    /// ### Single child strategy
+    /// When there is only one child, it's not possible to make sure of the group value that should be create: array or dictionary. The `default` strategy will look at the
+    /// child name. If it's the default XML element name, an array will be created. Otherwise, it will be a dictionary. A custom function can be used.
+    public func explorerValue(keepingAttributes: Bool = true, singleChildStrategy: SingleChildStrategy = .default) -> ExplorerValue {
+        if children.isEmpty {
+            return singleExplorerValue(keepingAttributes: keepingAttributes)
+        }
+
+        if children.count == 1 {
+            let name = children[0].name
+            let value = children[0].explorerValue(keepingAttributes: keepingAttributes, singleChildStrategy: singleChildStrategy)
+            return singleChildStrategy.transform(name, value)
+        }
+
+        if let names = uniqueChildrenNames, names.count > 1 { // dict
+            let dict = children.map { (key: $0.name, value: $0.explorerValue(keepingAttributes: keepingAttributes, singleChildStrategy: singleChildStrategy)) }
+            let dictValue = ExplorerValue.dictionary(Dictionary(uniqueKeysWithValues: dict))
+            return keepingAttributes ? valueWithAttributes(value: dictValue) : dictValue
+        } else { // array
+
+            let arrayValue = ExplorerValue.array(children.map { $0.explorerValue(keepingAttributes: keepingAttributes, singleChildStrategy: singleChildStrategy) })
+            return keepingAttributes ? valueWithAttributes(value: arrayValue) : arrayValue
+        }
+    }
+
+    private func singleExplorerValue(keepingAttributes: Bool) -> ExplorerValue {
+        let value: ExplorerValue
+        if let int = self.int {
+            value = .int(int)
+        } else if let double = self.double {
+            value = .double(double)
+        } else if let bool = self.bool {
+            value = .bool(bool)
+        } else {
+            value = .string(self.string ?? "")
+        }
+
+        return keepingAttributes ? valueWithAttributes(value: value) : value
+    }
+
+    private func valueWithAttributes(value: ExplorerValue) -> ExplorerValue {
+        if attributes.isEmpty {
+            return value
+        } else {
+            return .dictionary(["attributes": attributes.explorerValue(), "value": value])
+        }
+    }
+
+    public struct SingleChildStrategy {
+        public typealias Transform = (_ key: String, _ value: ExplorerValue) -> ExplorerValue
+        var transform: Transform
+
+        init(transform: @escaping Transform) {
+            self.transform = transform
+        }
+
+        public static let dictionary = SingleChildStrategy { (key, value) -> ExplorerValue in .dictionary([key: value]) }
+        public static let array = SingleChildStrategy { (_, value) -> ExplorerValue in .array([value]) }
+        public static func custom(_ transform: @escaping Transform) -> SingleChildStrategy {
+            SingleChildStrategy { (key, value) in transform(key, value) }
+        }
+
+        public static let `default` = SingleChildStrategy { (key, value) in
+            if key == Element.defaultName {
+                return array.transform(key, value)
+            } else {
+                return dictionary.transform(key, value)
+            }
+        }
+    }
+}

--- a/Sources/Scout/ExplorerXML/ExplorerXML.swift
+++ b/Sources/Scout/ExplorerXML/ExplorerXML.swift
@@ -202,7 +202,7 @@ extension ExplorerXML {
         return self
     }
 
-    func set(value: String) {
+    func set(value: String?) {
         element.value = value
     }
 
@@ -247,15 +247,6 @@ extension ExplorerXML {
     /// A new `ExplorerXML` with a new element and new children, keeping the name, value and attributes
     func copy() -> Self {
         ExplorerXML(element: element.copy())
-    }
-}
-
-extension ExplorerXML {
-
-    enum GroupSample {
-        case filter, slice
-
-        static var keySeparator: String { "_" }
     }
 }
 

--- a/Sources/Scout/ExplorerXML/ExplorerXML.swift
+++ b/Sources/Scout/ExplorerXML/ExplorerXML.swift
@@ -21,6 +21,7 @@ public struct ExplorerXML: PathExplorer {
     private var element: AEXMLElement
     var name: String { element.name }
     var xml: String { element.xml }
+    var attributes: [String: String] { element.attributes }
     func attribute(named name: String) -> String? { element.attributes[name] }
 
     // MARK: PathExplorer
@@ -28,56 +29,10 @@ public struct ExplorerXML: PathExplorer {
     public var string: String? { element.string.trimmingCharacters(in: .whitespacesAndNewlines) == "" ? nil : element.string }
     public var bool: Bool? { element.bool }
     public var int: Int? { element.int }
+    public var double: Double? { element.double }
+
+    @available(*, deprecated)
     public var real: Double? { element.double }
-
-    /// The `ExplorerValue` conversion of the XML element
-    /// ### Complexity
-    /// `O(n)`  where `n` is the sum of all children
-    ///
-    /// ### Attributes
-    /// If a XML element has attributes and `keepingAttributes` is `true`,
-    /// the format of the returned `ExplorerValue` will be modified to
-    /// a dictionary with two keys:"attributes" which holds the attributes of the element as `[String: String]`
-    /// and "value" which holds the `ExplorerValue` conversion of the element.
-    public func explorerValue(keepingAttributes: Bool = true) -> ExplorerValue {
-        if children.isEmpty {
-            return singleExplorerValue(keepingAttributes: keepingAttributes)
-        }
-
-        #warning("It might be useful to offer a strategy customisation for single elements: array or dict")
-        if let names = element.uniqueChildrenNames, names.count > 1 { // dict
-            let dict = children.map { (key: $0.name, value: $0.explorerValue(keepingAttributes: keepingAttributes)) }
-            let dictValue = ExplorerValue.dictionary(Dictionary(uniqueKeysWithValues: dict))
-            return keepingAttributes ? valueWithAttributes(value: dictValue) : dictValue
-        } else { // array
-
-            let arrayValue = ExplorerValue.array(children.map { $0.explorerValue(keepingAttributes: keepingAttributes) })
-            return keepingAttributes ? valueWithAttributes(value: arrayValue) : arrayValue
-        }
-    }
-
-    private func singleExplorerValue(keepingAttributes: Bool) -> ExplorerValue {
-        let value: ExplorerValue
-        if let int = element.int {
-            value = .int(int)
-        } else if let double = element.double {
-            value = .double(double)
-        } else if let bool = element.bool {
-            value = .bool(bool)
-        } else {
-            value = .string(element.string)
-        }
-
-        return keepingAttributes ? valueWithAttributes(value: value) : value
-    }
-
-    private func valueWithAttributes(value: ExplorerValue) -> ExplorerValue {
-        if element.attributes.isEmpty {
-            return value
-        } else {
-            return .dictionary(["attributes": element.attributes.explorerValue(), "value": value])
-        }
-    }
 
     /// Always `nil` on XML
     public var data: Data? { nil }
@@ -189,6 +144,9 @@ extension ExplorerXML {
 
     /// `true` if all children have the same name
     var childrenHaveCommonName: Bool { element.commonChildrenName != nil }
+
+    /// All children names. `nil` if two names are reused
+    var uniqueChildrenNames: Set<String>? { element.uniqueChildrenNames }
 
     var children: [ExplorerXML] {
         get { element.children.map { ExplorerXML(element: $0) }}

--- a/Sources/Scout/Extensions/AEXML/AEXMLElement+Children.swift
+++ b/Sources/Scout/Extensions/AEXML/AEXMLElement+Children.swift
@@ -31,22 +31,16 @@ extension AEXMLElement {
     var childrenName: String { children.first?.name ?? name }
 
     /// The common name of all the children if one is found
-    /// - note: Handles the case where the name is a path leading to the key when using dictionary filters
     var commonChildrenName: String? {
-        guard
-            let firstChild = children.first,
-            let name = firstChild.name.components(separatedBy: ExplorerXML.GroupSample.keySeparator).last
-        else {
+        guard let firstChildName = children.first?.name else {
             return nil
         }
 
-        for child in children {
-            if child.name.components(separatedBy: ExplorerXML.GroupSample.keySeparator).last != name {
-                return nil
-            }
+        if !children.allSatisfy({ $0.name == firstChildName }) {
+            return nil
         }
 
-        return name
+        return firstChildName
     }
 
     /// `true` if all the children have a different name

--- a/Sources/Scout/Extensions/Collection+Extensions.swift
+++ b/Sources/Scout/Extensions/Collection+Extensions.swift
@@ -13,3 +13,26 @@ extension RandomAccessCollection {
         return (head, dropFirst())
     }
 }
+
+extension Collection {
+
+    /// Unwrap all the elements mapped by the provided function. If one unwrap fails, `nil` is returned
+    func unwrapAll<T>(_ transform: (Element) throws -> T?) rethrows -> [T]? {
+        var unwrapped: [T] = []
+
+        for element in self {
+            if let transformed = try transform(element) {
+                unwrapped.append(transformed)
+            } else {
+                return nil
+            }
+        }
+
+        return unwrapped
+    }
+
+    /// Unwrap all the elements mapped by the provided key path. If one unwrap fails, `nil` is returned
+    func unwrapAll<T>(_ keyPath: KeyPath<Element, T?>) -> [T]? {
+        unwrapAll { $0[keyPath: keyPath] }
+    }
+}

--- a/Sources/Scout/Models/Path/Collection+Path.swift
+++ b/Sources/Scout/Models/Path/Collection+Path.swift
@@ -5,34 +5,39 @@
 
 import Foundation
 
+public extension Collection where Element == PathElement {
+
+    /// Compare key or index when found at the same position
+    func comparedByKeyAndIndexes(with otherPath: Path) -> Bool {
+        var lhsIterator = makeIterator()
+        var rhsIterator = otherPath.makeIterator()
+
+        while let lhsElement = lhsIterator.next(), let rhsElement = rhsIterator.next() {
+            switch (lhsElement, rhsElement) {
+
+            case (.key(let lhsLabel), .key(let rhsLabel)):
+                if lhsLabel != rhsLabel {
+                    return lhsLabel < rhsLabel
+                }
+
+            case (.index(let lhsIndex), .index(let rhsIndex)):
+                if lhsIndex != rhsIndex {
+                    return lhsIndex < rhsIndex
+                }
+
+            default:
+                return true
+            }
+        }
+
+        return count < otherPath.count // put the shorter path before
+    }
+}
+
 public extension Collection where Element == Path {
 
     /// Sort by key or index when found at the same position
     func sortedByKeysAndIndexes() -> [Path] {
-        sorted { (lhs, rhs) in
-
-            var lhsIterator = lhs.makeIterator()
-            var rhsIterator = rhs.makeIterator()
-
-            while let lhsElement = lhsIterator.next(), let rhsElement = rhsIterator.next() {
-                switch (lhsElement, rhsElement) {
-
-                case (.key(let lhsLabel), .key(let rhsLabel)):
-                    if lhsLabel != rhsLabel {
-                        return lhsLabel < rhsLabel
-                    }
-
-                case (.index(let lhsIndex), .index(let rhsIndex)):
-                    if lhsIndex != rhsIndex {
-                        return lhsIndex < rhsIndex
-                    }
-
-                default:
-                    return true
-                }
-            }
-
-            return lhs.count < rhs.count // put the shorter path before
-        }
+        sorted { (lhs, rhs) in lhs.comparedByKeyAndIndexes(with: rhs) }
     }
 }

--- a/Sources/Scout/Models/Path/PathTree.swift
+++ b/Sources/Scout/Models/Path/PathTree.swift
@@ -5,7 +5,13 @@
 
 import Foundation
 
-final class PathTree<Value> {
+/// A collection of paths arranged following their common prefixes.
+///
+/// Useful when building a PathExplorer from a list of paths to reuse the last created explorer
+/// to add children to it (rather than starting again from the root each time).
+final class PathTree<Value: Equatable> {
+
+    // MARK: - Properties
 
     let element: PathElement
     var value: ValueType
@@ -24,6 +30,8 @@ final class PathTree<Value> {
         return nil
     }
 
+    // MARK: - Initialisation
+
     init(value: ValueType, element: PathElement) {
         self.value = value
         self.element = element
@@ -40,11 +48,41 @@ final class PathTree<Value> {
     static func root() -> PathTree {
         .node(children: [], element: .key("root"))
     }
+}
+
+// MARK: - Subscript
+
+extension PathTree {
+
+    subscript(_ element: PathElement) -> PathTree? {
+        switch value {
+        case .uninitializedLeaf, .leaf: return nil
+        case .node(let children): return children.first { $0.element == element }
+        }
+    }
+
+    subscript(path: Path) -> PathTree? {
+        var currentTree = self
+        for element in path {
+            if let tree = currentTree[element] {
+                currentTree = tree
+            } else {
+                return nil
+            }
+        }
+        return currentTree
+    }
+}
+
+// MARK: - Children
+
+extension PathTree {
 
     /// Add a node to the tree.
     /// - note: If the tree is a leaf, it will be transformed into a node with children
     func addChild(_ child: PathTree) {
         switch value {
+        case .uninitializedLeaf: break
         case .leaf: value = .node(children: [child])
         case .node(var children):
             children.append(child)
@@ -58,17 +96,65 @@ final class PathTree<Value> {
     }
 }
 
+extension PathTree: Equatable {
+    static func == (lhs: PathTree<Value>, rhs: PathTree<Value>) -> Bool {
+        lhs.element == rhs.element && lhs.value == rhs.value
+    }
+}
+
+// MARK: - Equatable
+
 extension PathTree {
 
-    enum ValueType {
+    enum ValueType: Equatable {
+        case uninitializedLeaf
         case leaf(value: Value)
         case node(children: [PathTree])
     }
 }
 
+// MARK: - Paths insertion
+
+extension PathTree {
+
+    /// Insert the path in the tree, returning the leaf that holds the last path's elements
+    func insert(path: Path) -> PathTree {
+        insert(path: Slice(path))
+    }
+
+    /// Insert the path in the tree, returning the leaf that holds the last path's elements
+    func insert(path: Slice<Path>) -> PathTree {
+        guard let (head, tail) = path.headAndTail() else { return self }
+        let insertedChild: PathTree
+
+        switch value {
+
+        case .uninitializedLeaf, .leaf:
+            let child = PathTree(value: .uninitializedLeaf, element: head)
+            insertedChild = child.insert(path: tail)
+            value = .node(children: [child])
+
+        case .node(var children):
+            if let existing = children.first(where: { $0.element == head }) {
+                insertedChild = existing.insert(path: tail)
+            } else {
+                let child = PathTree(value: .uninitializedLeaf, element: head)
+                insertedChild = child.insert(path: tail)
+                children.append(child)
+            }
+
+            value = .node(children: children)
+        }
+
+        return insertedChild
+    }
+}
+
+// MARK: - PathExplorer
+
 extension ExplorerXML {
 
-    static func newValue(exploring tree: PathTree<String>) throws -> ExplorerXML {
+    static func newValue(exploring tree: PathTree<String?>) throws -> ExplorerXML {
         let name: String
         switch tree.element {
         case .key(let key): name = key
@@ -81,11 +167,14 @@ extension ExplorerXML {
         switch tree.value {
         case .leaf(let value):
             explorer.set(value: value)
+
         case .node(let children):
             try children.forEach { childTree in
                 let childExplorer = try ExplorerXML.newValue(exploring: childTree)
                 explorer.addChild(childExplorer)
             }
+            
+        case .uninitializedLeaf: throw ExplorerError(description: "Uninitialized leaf encountered while building from PathTree")
         }
 
         return explorer
@@ -94,20 +183,28 @@ extension ExplorerXML {
 
 extension ExplorerValue {
 
-    static func newValue(exploring tree: PathTree<ExplorerValue>) throws -> ExplorerValue {
+    static func newValue(exploring tree: PathTree<ExplorerValue?>) throws -> ExplorerValue? {
         switch tree.value {
         case .leaf(let value):
             return value
 
         case .node(let children):
             if let mappedChildren = children.unwrapAll(\.keyed) {
-                let dict = try mappedChildren.map { try ($0.key, newValue(exploring: $0.tree)) }
+                let dict = try mappedChildren.compactMap { (key, tree) -> (String, ExplorerValue)? in
+                    if let value = try newValue(exploring: tree) {
+                        return (key, value)
+                    }
+                    return nil
+                }
                 return dictionary <^> Dictionary(uniqueKeysWithValues: dict)
+
             } else if let mappedChildren = children.unwrapAll(\.indexed) {
-                return try array <^> mappedChildren.map { try newValue(exploring: $0.tree) }
+                return try array <^> mappedChildren.compactMap { try newValue(exploring: $0.tree) }
             } else {
                 throw ExplorerError(description: "Invalid children values to build value from PathTree. Expected only keys or only indexes PathElements")
             }
+
+        case .uninitializedLeaf: throw ExplorerError(description: "Uninitialized leaf encountered while building from PathTree")
         }
     }
 }

--- a/Sources/Scout/Models/Path/PathTree.swift
+++ b/Sources/Scout/Models/Path/PathTree.swift
@@ -1,0 +1,113 @@
+//
+// Scout
+// Copyright (c) 2020-present Alexis Bridoux
+// MIT license, see LICENSE file for details
+
+import Foundation
+
+final class PathTree<Value> {
+
+    let element: PathElement
+    var value: ValueType
+
+    var keyed: (key: String, tree: PathTree)? {
+        if let key = element.key {
+            return (key, self)
+        }
+        return nil
+    }
+
+    var indexed: (index: Int, tree: PathTree)? {
+        if let index = element.index {
+            return (index, self)
+        }
+        return nil
+    }
+
+    init(value: ValueType, element: PathElement) {
+        self.value = value
+        self.element = element
+    }
+
+    static func leaf(value: Value, element: PathElement) -> PathTree {
+        PathTree(value: .leaf(value: value), element: element)
+    }
+
+    static func node(children: [PathTree], element: PathElement) -> PathTree {
+        PathTree(value: .node(children: children), element: element)
+    }
+
+    static func root() -> PathTree {
+        .node(children: [], element: .key("root"))
+    }
+
+    /// Add a node to the tree.
+    /// - note: If the tree is a leaf, it will be transformed into a node with children
+    func addChild(_ child: PathTree) {
+        switch value {
+        case .leaf: value = .node(children: [child])
+        case .node(var children):
+            children.append(child)
+            value = .node(children: children)
+        }
+    }
+
+    func addLeaf(value: Value, element: PathElement) {
+        let leaf = Self.leaf(value: value, element: element)
+        addChild(leaf)
+    }
+}
+
+extension PathTree {
+
+    enum ValueType {
+        case leaf(value: Value)
+        case node(children: [PathTree])
+    }
+}
+
+extension ExplorerXML {
+
+    static func newValue(exploring tree: PathTree<String>) throws -> ExplorerXML {
+        let name: String
+        switch tree.element {
+        case .key(let key): name = key
+        case .index: name = Element.defaultName
+        default: throw ExplorerError.wrongUsage(of: tree.element)
+        }
+
+        let explorer = ExplorerXML(name: name)
+
+        switch tree.value {
+        case .leaf(let value):
+            explorer.set(value: value)
+        case .node(let children):
+            try children.forEach { childTree in
+                let childExplorer = try ExplorerXML.newValue(exploring: childTree)
+                explorer.addChild(childExplorer)
+            }
+        }
+
+        return explorer
+    }
+}
+
+extension ExplorerValue {
+
+    static func newValue(exploring tree: PathTree<ExplorerValue>) throws -> ExplorerValue {
+        switch tree.value {
+        case .leaf(let value):
+            return value
+
+        case .node(let children):
+            if let mappedChildren = children.unwrapAll(\.keyed) {
+                let dict = try mappedChildren.map { try ($0.key, newValue(exploring: $0.tree)) }
+                return dictionary <^> Dictionary(uniqueKeysWithValues: dict)
+            } else if let mappedChildren = children.unwrapAll(\.indexed) {
+                return try array <^> mappedChildren.map { try newValue(exploring: $0.tree) }
+            } else {
+                throw ExplorerError(description: "Invalid children values to build value from PathTree. Expected only keys or only indexes PathElements")
+            }
+        }
+    }
+}

--- a/Sources/Scout/Models/PathExplorer/CodablePathExplorer+Serialization.swift
+++ b/Sources/Scout/Models/PathExplorer/CodablePathExplorer+Serialization.swift
@@ -45,6 +45,10 @@ extension CodablePathExplorer: SerializablePathExplorer {
         try value.exportCSV(separator: separator ?? defaultCSVSeparator)
     }
 
+    public static func fromCSV(string: String, separator: Character, hasHeaders: Bool) throws -> CodablePathExplorer<Format> {
+        try Self(value: .fromCSV(string: string, separator: separator, hasHeaders: hasHeaders))
+    }
+
     public func folded(upTo level: Int) -> Self {
         Self(value: value.folded(upTo: level))
     }

--- a/Sources/Scout/Models/PathExplorer/PathExplorer+ExploreWithMemory.swift
+++ b/Sources/Scout/Models/PathExplorer/PathExplorer+ExploreWithMemory.swift
@@ -14,21 +14,21 @@ extension PathExplorer {
     /// - Parameters:
     ///   - paths: The paths to get
     ///   - block: The block to execute with the explorer retrieved for the path
-    func explore(paths: [Path], using block: (Result<Self, ExplorerError>) throws -> Void) rethrows {
-        let history = History(origin: self)
-        try paths.forEach { try  history.explore(path: $0, using: block) }
+    func exploreWithMemory(paths: [Path], using block: (Result<Self, ExplorerError>) throws -> Void) rethrows {
+        let history = GetMemory(origin: self)
+        try paths.forEach { try history.explore(path: $0, using: block) }
     }
 
-    func exploreReduce<T>(initial: T, paths: [Path], using transform: (_ result: T, _ explorer: Result<Self, ExplorerError>) throws -> T) rethrows -> T {
+    func reduceWithMemory<T>(initial: T, paths: [Path], using transform: (_ result: T, _ explorer: Result<Self, ExplorerError>) throws -> T) rethrows -> T {
         var result = initial
-        try explore(paths: paths) { (explorer) in
+        try exploreWithMemory(paths: paths) { (explorer) in
             result = try transform(result, explorer)
         }
         return result
     }
 }
 
-private final class History<Explorer: PathExplorer> {
+private final class GetMemory<Explorer: PathExplorer> {
     let origin: Explorer
     private(set) var lastExploredPath: Slice<Path> = Slice(Path.empty)
     private(set) var lastExplorers: ArraySlice<Explorer> = []
@@ -39,7 +39,7 @@ private final class History<Explorer: PathExplorer> {
     }
 
     func explore(path: Path, using exploringHandler: (Result<Explorer, ExplorerError>) throws -> Void) rethrows {
-        // explorer only the difference
+        // explore only the difference
         let differenceToExplore = suffixDifference(with: path)
         var currentExplorer = lastExplorer
 

--- a/Sources/Scout/Models/PathExplorer/SerializablePathExplorer.swift
+++ b/Sources/Scout/Models/PathExplorer/SerializablePathExplorer.swift
@@ -32,6 +32,9 @@ public protocol SerializablePathExplorer: PathExplorer {
     /// Export the path explorer value to the specified format string data with a default root name "root"
     func exportString(to format: DataFormat, rootName: String?) throws -> String
 
+    /// Returns a new explorer from the provided CSV string when it's possible. Throws otherwise.
+    static func fromCSV(string: String, separator: Character, hasHeaders: Bool) throws -> Self
+
     /// New explorer replacing the group values (array or dictionaries) sub values by a unique one
     /// holding a fold mark to be replaced when exporting the string value.
     /// - note: Use `exportFoldedString(upTo:)` to directly get the string value

--- a/Sources/Scout/Models/PathParser/Path+PathParser.swift
+++ b/Sources/Scout/Models/PathParser/Path+PathParser.swift
@@ -6,64 +6,60 @@
 import Foundation
 
 extension Path {
+    enum ElementParsers {}
+}
 
-    static func keyParser(separator: String) -> PathParser<PathElement> {
+extension Path.ElementParsers {
+
+    static func key(separator: String) -> PathParser<PathElement> {
         PathParsers.string(stoppingAt: separator, forbiddenCharacters: "[", "{").map(PathElement.key)
     }
 
-    static var parenthesisedKeyParser: PathParser<PathElement> {
+    static var parenthesisedKey: PathParser<PathElement> {
         PathParsers.string(forbiddenCharacters: ")").parenthesised.map(PathElement.key)
     }
 
-    static var indexParser: PathParser<PathElement> {
+    static var index: PathParser<PathElement> {
         PathParsers.signedInteger.parenthesisedSquare.map(PathElement.index)
     }
 
-    static var countParser: PathParser<PathElement> {
+    static var count: PathParser<PathElement> {
         PathParsers.character("#").parenthesisedSquare.map { _ in PathElement.count }
     }
 
-    static var keysListParser: PathParser<PathElement> {
+    static var keysList: PathParser<PathElement> {
         PathParsers.character("#").parenthesisedCurl.map { _ in PathElement.keysList }
     }
 
-    static var boundsParser: PathParser<Bounds> {
+    static var bounds: PathParser<Bounds> {
         curry { (lower, _, upper) in Bounds(lower: lower, upper: upper) }
             <^> PathParsers.signedInteger.optional
             <*> .character(":")
             <*> PathParsers.signedInteger.optional
     }
 
-    static var sliceParser: PathParser<PathElement> {
-        boundsParser.map(PathElement.slice).parenthesisedSquare
+    static var slice: PathParser<PathElement> {
+        bounds.map(PathElement.slice).parenthesisedSquare
     }
 
-    static var filterParser: PathParser<PathElement> {
+    static var filter: PathParser<PathElement> {
         PathParsers.string(stoppingAt: "#").enclosed(by: "#").map(PathElement.filter)
     }
 
-    static func singlePathElementParser(separator: String) -> PathParser<PathElement> {
-        filterParser
-            <|> sliceParser
-            <|> countParser
-            <|> keysListParser
-            <|> indexParser
-            <|> parenthesisedKeyParser
-            <|> keyParser(separator: separator)
+    static func singlePathElement(separator: String) -> PathParser<PathElement> {
+        filter
+            <|> slice
+            <|> count
+            <|> keysList
+            <|> index
+            <|> parenthesisedKey
+            <|> key(separator: separator)
     }
 }
 
 extension Path {
 
-    static func pathElementWithIndexing(separator: String) -> PathParser<[PathElement]> {
-        curry { [$0] + $1 } <^> singlePathElementParser(separator: separator) <*> (indexParser <|> sliceParser).many
-    }
-
     static func parser(separator: String) -> PathParser<[PathElement]> {
-        (pathElementWithIndexing(separator: separator) <* PathParsers.string(separator).optional)
-            .many
-            .map { elements in
-                elements.flatMap { $0 }
-            }
+        (ElementParsers.singlePathElement(separator: separator) <* PathParsers.string(separator).optional).many
     }
 }

--- a/Tests/ScoutTests/Definitions/PathParserTests.swift
+++ b/Tests/ScoutTests/Definitions/PathParserTests.swift
@@ -8,9 +8,11 @@ import XCTest
 
 final class PathParserTests: XCTestCase {
 
+    typealias ElementParsers = Path.ElementParsers
+
     func testKey() {
         test(
-            parser: Path.keyParser(separator: "."),
+            parser: ElementParsers.key(separator: "."),
             on: "firstKey.secondKey",
             expected: "firstKey"
         )
@@ -18,7 +20,7 @@ final class PathParserTests: XCTestCase {
 
     func testIndex() {
         test(
-            parser: Path.indexParser,
+            parser: ElementParsers.index,
             on: "[10]",
             expected: 10
         )
@@ -26,7 +28,7 @@ final class PathParserTests: XCTestCase {
 
     func testIndex_Negative() {
         test(
-            parser: Path.indexParser,
+            parser: ElementParsers.index,
             on: "[-10]",
             expected: -10
         )
@@ -34,7 +36,7 @@ final class PathParserTests: XCTestCase {
 
     func testIndex_Positive() {
         test(
-            parser: Path.indexParser,
+            parser: ElementParsers.index,
             on: "[+10]",
             expected: 10
         )
@@ -42,7 +44,7 @@ final class PathParserTests: XCTestCase {
 
     func testSlice_Full() {
         test(
-            parser: Path.sliceParser,
+            parser: ElementParsers.slice,
             on: "[2:13]",
             expected: .slice(2, 13)
         )
@@ -50,7 +52,7 @@ final class PathParserTests: XCTestCase {
 
     func testSlice_NoLeft() {
         test(
-            parser: Path.sliceParser,
+            parser: ElementParsers.slice,
             on: "[:13]",
             expected: .slice(.first, 13)
         )
@@ -58,7 +60,7 @@ final class PathParserTests: XCTestCase {
 
     func testSlice_NoRight() {
         test(
-            parser: Path.sliceParser,
+            parser: ElementParsers.slice,
             on: "[2:]",
             expected: .slice(2, .last)
         )
@@ -66,7 +68,7 @@ final class PathParserTests: XCTestCase {
 
     func testSlice_NoLeftNoRight() {
         test(
-            parser: Path.sliceParser,
+            parser: ElementParsers.slice,
             on: "[:]",
             expected: .slice(.first, .last)
         )
@@ -74,7 +76,7 @@ final class PathParserTests: XCTestCase {
 
     func testFilter() {
         test(
-            parser: Path.filterParser,
+            parser: ElementParsers.filter,
             on: "#Toto|Endo#",
             expected: .filter("Toto|Endo")
         )

--- a/Tests/ScoutTests/PathExplorerTestsSuite/PathExplorer+CSVImport.swift
+++ b/Tests/ScoutTests/PathExplorerTestsSuite/PathExplorer+CSVImport.swift
@@ -127,6 +127,6 @@ extension PathExplorerCSVImportTests {
         let explorer = try P.fromCSV(string: csv, separator: ";", hasHeaders: headers)
         let expectedExplorer = P(value: expected)
 
-        XCTAssertExplorersEqual(explorer, expectedExplorer,file: file, line: line)
+        XCTAssertExplorersEqual(explorer, expectedExplorer, file: file, line: line)
     }
 }

--- a/Tests/ScoutTests/PathExplorerTestsSuite/PathExplorer+CSVImport.swift
+++ b/Tests/ScoutTests/PathExplorerTestsSuite/PathExplorer+CSVImport.swift
@@ -15,7 +15,7 @@ final class PathExplorerCSVImportTests: XCTestCase {
     }
 
     func testExplorerXML() throws {
-//        try test(ExplorerXML.self)
+        try test(ExplorerXML.self)
     }
 
     func test<P: Explorer>(_ type: P.Type) throws {

--- a/Tests/ScoutTests/PathExplorerTestsSuite/PathExplorer+CSVImport.swift
+++ b/Tests/ScoutTests/PathExplorerTestsSuite/PathExplorer+CSVImport.swift
@@ -1,0 +1,132 @@
+//
+// Scout
+// Copyright (c) 2020-present Alexis Bridoux
+// MIT license, see LICENSE file for details
+
+@testable import Scout
+import XCTest
+
+final class PathExplorerCSVImportTests: XCTestCase {
+
+    typealias Explorer = EquatablePathExplorer & SerializablePathExplorer
+
+    func testExplorerValue() throws {
+        try test(PathExplorers.Json.self)
+    }
+
+    func testExplorerXML() throws {
+//        try test(ExplorerXML.self)
+    }
+
+    func test<P: Explorer>(_ type: P.Type) throws {
+        try testImportCSV_ArrayOfDictionaries(P.self)
+        try testImportCSV_ArrayOfDictionaries_NestedArray(P.self)
+        try testImportCSV_ArrayOfDictionaries_NestedDict(P.self)
+        try testImportCSV_ArrayOfArrays(P.self)
+        try testImportCSV_ArrayOfSingles(P.self)
+    }
+
+    func testStub() throws {
+        // use this function to launch a test with a specific PathExplorer
+    }
+
+    // MARK: - Suite
+
+    func testImportCSV_ArrayOfDictionaries<P: Explorer>(_ type: P.Type) throws {
+        try test(
+            P.self,
+            csv:
+            """
+            Riri;Fifi;Loulou
+            1;2;3
+            4;5;6
+            7;8;9
+            """,
+            headers: true,
+            expected:
+                [["Riri": 1, "Fifi": 2, "Loulou": 3],
+                ["Riri": 4, "Fifi": 5, "Loulou": 6],
+                ["Riri": 7, "Fifi": 8, "Loulou": 9]]
+        )
+    }
+
+    func testImportCSV_ArrayOfDictionaries_NestedArray<P: Explorer>(_ type: P.Type) throws {
+        try test(
+            P.self,
+            csv:
+            """
+            name;hobbies[0];hobbies[1];score
+            Tom;cooking;video games;20.5
+            Robert;surfing;cluedo;30.2
+            """,
+            headers: true,
+            expected:
+                [["name": "Tom", "hobbies": ["cooking", "video games"], "score": 20.5],
+                 ["name": "Robert", "hobbies": ["surfing", "cluedo"], "score": 30.2]]
+        )
+    }
+
+    func testImportCSV_ArrayOfDictionaries_NestedDict<P: Explorer>(_ type: P.Type) throws {
+        try test(
+            P.self,
+            csv:
+            """
+            name.first;name.last;score
+            Riri;Duck;20.5
+            Fifi;Duck;30.2
+            Loulou;Duck;10
+
+            """,
+            headers: true,
+            expected:
+                [["name": ["first": "Riri", "last": "Duck"], "score": 20.5],
+                 ["name": ["first": "Fifi", "last": "Duck"], "score": 30.2],
+                 ["name": ["first": "Loulou", "last": "Duck"], "score": 10]]
+        )
+    }
+
+    func testImportCSV_ArrayOfArrays<P: Explorer>(_ type: P.Type) throws {
+        try test(
+            P.self,
+            csv:
+            """
+            Riri;2;3
+            Fifi;5;6
+            Loulou;8;9
+            """,
+            headers: false,
+            expected: [["Riri", 2, 3], ["Fifi", 5, 6], ["Loulou", 8, 9]]
+        )
+    }
+
+    func testImportCSV_ArrayOfSingles<P: Explorer>(_ type: P.Type) throws {
+        try test(
+            P.self,
+            csv:
+            """
+            1;2;3;4;5;6
+            """,
+            headers: false,
+            expected: [1, 2, 3, 4, 5, 6]
+        )
+    }
+}
+
+// MARK: - Helpers
+
+extension PathExplorerCSVImportTests {
+
+    func test<P: EquatablePathExplorer & SerializablePathExplorer>(
+        _ type: P.Type,
+        csv: String,
+        headers: Bool,
+        expected: ExplorerValue,
+        file: StaticString = #file,
+        line: UInt = #line) throws {
+
+        let explorer = try P.fromCSV(string: csv, separator: ";", hasHeaders: headers)
+        let expectedExplorer = P(value: expected)
+
+        XCTAssertExplorersEqual(explorer, expectedExplorer,file: file, line: line)
+    }
+}

--- a/Tests/ScoutTests/PathExplorerTestsSuite/PathExplorerTests+Add.swift
+++ b/Tests/ScoutTests/PathExplorerTestsSuite/PathExplorerTests+Add.swift
@@ -33,6 +33,7 @@ final class PathExplorerAddTests: XCTestCase {
         try testAddIndex(P.self)
         try testAddIndex_Negative(P.self)
         try testAddIndex_NestedIndex(P.self)
+        try testAddIndex_ArrayCount(P.self)
         try testAddIndex_NestedKey(P.self)
         try testAddIndex_GroupValue(P.self)
 
@@ -130,6 +131,16 @@ final class PathExplorerAddTests: XCTestCase {
             path: -2,
             value: 2.5,
             expected: [1, 2.5, true, "hello"]
+        )
+    }
+
+    func testAddIndex_ArrayCount<P: EquatablePathExplorer>(_ type: P.Type) throws {
+        try testAdd(
+            P.self,
+            initial: [1, true, "hello"],
+            path: 3,
+            value: 2.5,
+            expected: [1, true, "hello", 2.5]
         )
     }
 

--- a/Tests/ScoutTests/PathExplorerTestsSuite/PathExplorerTests+CSVExport.swift
+++ b/Tests/ScoutTests/PathExplorerTestsSuite/PathExplorerTests+CSVExport.swift
@@ -31,6 +31,8 @@ final class PathExplorerCSVExportTests: XCTestCase {
         // use this function to launch a test with a specific PathExplorer
     }
 
+    // MARK: - Suite
+
     func testExportCSV_SingleValues<P: SerializablePathExplorer>(_ type: P.Type) throws {
         try testExportCSV(
             P.self,

--- a/Tests/ScoutTests/PathTree/PathTreeTests.swift
+++ b/Tests/ScoutTests/PathTree/PathTreeTests.swift
@@ -1,0 +1,44 @@
+//
+// Scout
+// Copyright (c) 2020-present Alexis Bridoux
+// MIT license, see LICENSE file for details
+
+@testable import Scout
+import XCTest
+
+final class PathTreeTests: XCTestCase {
+
+    func testExplorerValueFromTree() throws {
+        typealias Tree = PathTree<ExplorerValue>
+        let root = Tree.root()
+        let tom = Tree.node(children: [], element: "Tom")
+        root.addChild(tom)
+        tom.addLeaf(value: 30, element: "score")
+        let hobbies = Tree.node(children: [], element: "hobbies")
+        hobbies.addLeaf(value: "surfing", element: 0)
+        hobbies.addLeaf(value: "cooking", element: 1)
+        tom.addChild(hobbies)
+
+        let value = try ExplorerValue.newValue(exploring: root)
+
+        let expected: ExplorerValue = ["Tom": [ "score": 30, "hobbies": ["surfing", "cooking"]]]
+        XCTAssertEqual(value, expected)
+    }
+
+    func testExplorerXMLFromTree() throws {
+        typealias Tree = PathTree<String>
+        let root = Tree.root()
+        let tom = Tree.node(children: [], element: "Tom")
+        root.addChild(tom)
+        tom.addLeaf(value: "30", element: "score")
+        let hobbies = Tree.node(children: [], element: "hobbies")
+        hobbies.addLeaf(value: "surfing", element: 0)
+        hobbies.addLeaf(value: "cooking", element: 1)
+        tom.addChild(hobbies)
+
+        let explorer = try ExplorerXML.newValue(exploring: root)
+
+        let expected: ExplorerValue = ["Tom": [ "score": 30, "hobbies": ["surfing", "cooking"]]]
+        XCTAssertEqual(explorer.explorerValue(), expected)
+    }
+}

--- a/Tests/ScoutTests/PathTree/PathTreeTests.swift
+++ b/Tests/ScoutTests/PathTree/PathTreeTests.swift
@@ -8,8 +8,74 @@ import XCTest
 
 final class PathTreeTests: XCTestCase {
 
+    // MARK: - Paths array
+
+    func testInsertPath() {
+        typealias Tree = PathTree<String>
+
+        let path = Path(elements: "Tom", "name", "first")
+        let root = Tree.root()
+        let first = root.insert(path: Slice(path))
+
+        XCTAssertNotNil(root["Tom"]?["name"]?["first"])
+        XCTAssertEqual(first.value, .uninitializedLeaf)
+        XCTAssertEqual(first.element, "first")
+    }
+
+    func testInsertTwoPaths_2ElementsCommonPrefix() {
+        typealias Tree = PathTree<String>
+
+        let path1 = Path(elements: "Tom", "name", "first")
+        let path2 = Path(elements: "Tom", "name", "last")
+        let root = Tree.root()
+        let first = root.insert(path: Slice(path1))
+        let last = root.insert(path: Slice(path2))
+
+        XCTAssertNotNil(root["Tom"]?["name"]?["first"])
+        XCTAssertNotNil(root["Tom"]?["name"]?["last"])
+        XCTAssertEqual(first.element, "first")
+        XCTAssertEqual(last.element, "last")
+        XCTAssertEqual(last.value, .uninitializedLeaf)
+    }
+
+    func testInsertTwoPaths_1ElementCommonPrefix() {
+        typealias Tree = PathTree<String>
+
+        let path1 = Path(elements: "Tom", "name", "first")
+        let path2 = Path(elements: "Tom", "score")
+        let root = Tree.root()
+        let first = root.insert(path: Slice(path1))
+        let score = root.insert(path: Slice(path2))
+
+        XCTAssertNotNil(root["Tom"]?["name"]?["first"])
+        XCTAssertNotNil(root["Tom"]?["score"])
+        XCTAssertEqual(first.element, "first")
+        XCTAssertEqual(score.element, "score")
+        XCTAssertEqual(score.value, .uninitializedLeaf)
+    }
+
+    func testBuildFromPathsSet() {
+        typealias Tree = PathTree<String>
+        let paths: [Path] = [Path("Tom", "hobbies", 0), Path("Tom", "hobbies", 1), Path("Tom", "name", "first"), Path("Tom", "name", "last")]
+        let root = Tree.root()
+
+        let trees = paths.map(root.insert)
+
+        XCTAssertNotNil(root[paths[0]])
+        XCTAssertNotNil(root[paths[1]])
+        XCTAssertNotNil(root[paths[2]])
+        XCTAssertNotNil(root[paths[3]])
+        XCTAssertEqual(trees[0].element, 0)
+        XCTAssertEqual(trees[1].element, 1)
+        XCTAssertEqual(trees[2].element, "first")
+        XCTAssertEqual(trees[3].element, "last")
+
+    }
+
+    // MARK: - PathExplorer
+
     func testExplorerValueFromTree() throws {
-        typealias Tree = PathTree<ExplorerValue>
+        typealias Tree = PathTree<ExplorerValue?>
         let root = Tree.root()
         let tom = Tree.node(children: [], element: "Tom")
         root.addChild(tom)
@@ -26,7 +92,7 @@ final class PathTreeTests: XCTestCase {
     }
 
     func testExplorerXMLFromTree() throws {
-        typealias Tree = PathTree<String>
+        typealias Tree = PathTree<String?>
         let root = Tree.root()
         let tom = Tree.node(children: [], element: "Tom")
         root.addChild(tom)


### PR DESCRIPTION
# Summary

Implement CSV import for `ExplorerValue` and `ExplorerXML`.

## Miscellaneous

The library SwiftCSV is used to parse CSV. Then depending on the headers option, the CSV is parsed as an array of arrays or as an array of dictionary.

With dictionaries, the CSV headers are treated as paths, allowing to deeply customise how the data will be structured.

### `PathTree`
To optimise this explorer build, the function `add` is not used as it starts from the root to the last element in the explorer. Rather, a `PathTree` is built from the header paths, returning the leafs storing the values. This way, for each row, leafs are populated with new values. Then the dictionary explorer  is built from the tree which is faster than building from a list of path as the last created is explorer will be immediately reused when adding children explorer to it.

Closes #181 
