### PR TITLE
Fix Swift 6.2 'Expression' type ambiguity

### DIFF
--- a/Sources/Scout/Models/PathsFilter/PathsFilter+ExpressionPredicate.swift
+++ b/Sources/Scout/Models/PathsFilter/PathsFilter+ExpressionPredicate.swift
@@ -20,7 +20,7 @@ extension PathsFilter {
 
         // MARK: Properties
 
-        private(set) var expression: Expression
+        private(set) var expression: BooleanExpressionEvaluation.Expression
 
         /// The value types that the operators in the expression support
         private(set) var operatorsValueTypes: Set<ValueType>
@@ -29,7 +29,7 @@ extension PathsFilter {
 
         /// Specify a predicate with a 'value' variable that will be replaced with a concrete value during evaluation
         public init(format: String) throws {
-            expression = try Expression(format)
+            expression = try BooleanExpressionEvaluation.Expression(format)
             operatorsValueTypes = expression.operators.reduce(Self.allValueTypesSet) { $0.intersection(Self.valueTypes(of: $1)) }
         }
     }
@@ -50,7 +50,7 @@ extension PathsFilter.ExpressionPredicate {
 
         do {
             return try expression.evaluate(with: ["value": String(describing: value)])
-        } catch ExpressionError.mismatchingType {
+        } catch BooleanExpressionEvaluation.ExpressionError.mismatchingType {
             // error of mismatching type for `valueType`. Remove it from the supported types
             operatorsValueTypes.remove(valueType)
             return false // ignore the error of wrong value type


### PR DESCRIPTION
Fixes #276. The issue was caused by ambiguity in Swift 6.2 where both  and  define types with similar names. This pull request resolves the ambiguity by explicitly qualifying the  and  types with the  module name.